### PR TITLE
DW-2263 - Healthcheck endpoint for data-key-service and tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ ci/terraform.tf
 .idea/
 rad/
 *.iml
+out/

--- a/README.md
+++ b/README.md
@@ -37,7 +37,27 @@ And then navigating to
 http://localhost:8080/swagger-ui.html#/data-key-controller
 ```
 
+# Healthcheck endpoint
 
+New GET endpoint on ‘/healthcheck’ reports the following
+
+- all dependencies can be reached,
+- the current master key id can be fetched,
+- a new key can be generated,
+- the new key is encrypted
+- the new key can be decrypted
+
+Response code is 200 if everything is OK, 500 otherwise. Example response body:
+
+```
+{
+"encryptionService": "OK",
+"masterKey": "OK",
+"dataKeyGenerator": "OK",
+"encryption": "OK",
+"decryption": “BAD”
+}
+```
 # Requirements for Data Key Service
 
 ## Runtime

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The API has been documented in swagger format (OpenAPI) using code annotations o
 you can also view them by running the service
 
 ```
-./gradlew bootRun
+SPRING_PROFILES_ACTIVE=AWS,KMS ./gradlew bootRun
 ```
 
 And then navigating to

--- a/build.gradle
+++ b/build.gradle
@@ -15,14 +15,18 @@ repositories {
     mavenCentral()
 }
 
+bootJar {
+    launchScript()
+}
+
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'com.google.guava:guava:27.0.1-jre'
     implementation 'org.springframework.boot:spring-boot-starter-web:2.1.4.RELEASE'
     implementation 'com.amazonaws:aws-java-sdk-kms:1.11.534'
     implementation 'com.amazonaws:aws-java-sdk-ssm:1.11.534'
     implementation "io.springfox:springfox-swagger2:2.9.2"
     implementation "io.springfox:springfox-swagger-ui:2.9.2"
-
     testImplementation 'org.springframework.boot:spring-boot-starter-test:2.1.4.RELEASE'
     testCompile "junit:junit:4.12"
 }

--- a/src/main/java/uk/gov/dwp/dataworks/controller/HealthCheckController.java
+++ b/src/main/java/uk/gov/dwp/dataworks/controller/HealthCheckController.java
@@ -1,0 +1,76 @@
+package uk.gov.dwp.dataworks.controller;
+
+import com.google.common.base.Strings;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.dwp.dataworks.dto.DecryptDataKeyResponse;
+import uk.gov.dwp.dataworks.dto.GenerateDataKeyResponse;
+import uk.gov.dwp.dataworks.dto.HealthCheckResponse;
+import uk.gov.dwp.dataworks.service.DataKeyService;
+
+@SuppressWarnings("unused")
+@RestController
+@RequestMapping("/healthcheck")
+@Api(value="healthcheck")
+public class HealthCheckController {
+
+    private final DataKeyService dataKeyService;
+    private final static Logger LOGGER = LoggerFactory.getLogger(DataKeyController.class);
+
+    @Autowired
+    public HealthCheckController(DataKeyService dataKeyService) {
+        this.dataKeyService = dataKeyService;
+    }
+
+    @RequestMapping(value = "", method = RequestMethod.GET)
+    @ApiOperation(value="A simple endpoint to confirm that the service is well configured and that its dependencies are fulfilled.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Service is healthy, all dependencies fine, can fulfill requests."),
+            @ApiResponse(code = 500, message = "Service is unhealthy, one or more dependencies can't be fullfilled. Response body indicates which.")
+    })
+
+    public ResponseEntity<HealthCheckResponse> healthCheck() {
+        boolean canReachDependencies = false;
+        boolean canRetrieveCurrentMasterKeyId = false;
+        boolean canCreateNewDataKey = false;
+        boolean canEncryptDataKey = false;
+        boolean canDecryptDataKey = false;
+        HealthCheckResponse health = new HealthCheckResponse();
+        try {
+            canReachDependencies = dataKeyService != null && dataKeyService.canSeeDependencies();
+            String currentKeyId = this.dataKeyService.currentKeyId();
+            canRetrieveCurrentMasterKeyId = ! Strings.isNullOrEmpty(currentKeyId);
+            GenerateDataKeyResponse encryptResponse = dataKeyService.generate();
+            canCreateNewDataKey = ! Strings.isNullOrEmpty(encryptResponse.dataKeyEncryptionKeyId) &&
+                                    ! Strings.isNullOrEmpty(encryptResponse.plaintextDataKey);
+            canEncryptDataKey = ! Strings.isNullOrEmpty(encryptResponse.ciphertextDataKey);
+            DecryptDataKeyResponse decryptResponse =
+                    dataKeyService.decrypt(encryptResponse.dataKeyEncryptionKeyId, encryptResponse.ciphertextDataKey);
+            canDecryptDataKey = ! Strings.isNullOrEmpty(decryptResponse.plaintextDataKey) &&
+                    decryptResponse.plaintextDataKey.equals(encryptResponse.plaintextDataKey);
+        }
+        finally {
+            health.setEncryptionService(canReachDependencies ? HealthCheckResponse.Health.OK : HealthCheckResponse.Health.BAD);
+            health.setMasterKey(canRetrieveCurrentMasterKeyId ? HealthCheckResponse.Health.OK : HealthCheckResponse.Health.BAD);
+            health.setDataKeyGenerator(canCreateNewDataKey ? HealthCheckResponse.Health.OK : HealthCheckResponse.Health.BAD);
+            health.setEncryption(canEncryptDataKey ? HealthCheckResponse.Health.OK : HealthCheckResponse.Health.BAD);
+            health.setDecryption(canDecryptDataKey ? HealthCheckResponse.Health.OK : HealthCheckResponse.Health.BAD);
+
+            boolean allOk = canReachDependencies && canRetrieveCurrentMasterKeyId &&
+                    canCreateNewDataKey && canEncryptDataKey &&  canDecryptDataKey;
+
+            return new ResponseEntity<>(health,
+                    allOk ? HttpStatus.OK : HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/uk/gov/dwp/dataworks/controller/HealthCheckController.java
+++ b/src/main/java/uk/gov/dwp/dataworks/controller/HealthCheckController.java
@@ -69,8 +69,7 @@ public class HealthCheckController {
             boolean allOk = canReachDependencies && canRetrieveCurrentMasterKeyId &&
                     canCreateNewDataKey && canEncryptDataKey &&  canDecryptDataKey;
 
-            return new ResponseEntity<>(health,
-                    allOk ? HttpStatus.OK : HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity<>(health, allOk ? HttpStatus.OK : HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/src/main/java/uk/gov/dwp/dataworks/dto/HealthCheckResponse.java
+++ b/src/main/java/uk/gov/dwp/dataworks/dto/HealthCheckResponse.java
@@ -1,9 +1,26 @@
 package uk.gov.dwp.dataworks.dto;
 
+import io.swagger.annotations.ApiModelProperty;
+
 @SuppressWarnings("unused")
 public class HealthCheckResponse {
 
     public enum Health {OK, BAD}
+
+    @ApiModelProperty(notes="Can the controller see its dependencies.")
+    private Health encryptionService;
+
+    @ApiModelProperty(notes="Can the controller fetch the current master key.")
+    private Health masterKey;
+
+    @ApiModelProperty(notes="Can the controller generate a new data key.")
+    private Health dataKeyGenerator;
+
+    @ApiModelProperty(notes="Can the controller encrypt a new data key.")
+    private Health encryption;
+
+    @ApiModelProperty(notes="Can the controller decrypt an encrypted data key.")
+    private Health decryption;
 
     public HealthCheckResponse() {
         this.encryptionService = Health.BAD;
@@ -22,12 +39,6 @@ public class HealthCheckResponse {
         this.encryption = encryption;
         this.decryption = decryption;
     }
-
-    private Health encryptionService;
-    private Health masterKey;
-    private Health dataKeyGenerator;
-    private Health encryption;
-    private Health decryption;
 
     public Health getEncryptionService() {
         return encryptionService;

--- a/src/main/java/uk/gov/dwp/dataworks/dto/HealthCheckResponse.java
+++ b/src/main/java/uk/gov/dwp/dataworks/dto/HealthCheckResponse.java
@@ -1,0 +1,72 @@
+package uk.gov.dwp.dataworks.dto;
+
+@SuppressWarnings("unused")
+public class HealthCheckResponse {
+
+    public enum Health {OK, BAD}
+
+    public HealthCheckResponse() {
+        this.encryptionService = Health.BAD;
+        this.masterKey = Health.BAD;
+        this.dataKeyGenerator = Health.BAD;
+        this.encryption = Health.BAD;
+        this.decryption = Health.BAD;
+    }
+
+    public HealthCheckResponse(Health encryptionService,
+            Health masterKey, Health dataKeyGenerator, Health encryption,
+            Health decryption) {
+        this.encryptionService = encryptionService;
+        this.masterKey = masterKey;
+        this.dataKeyGenerator = dataKeyGenerator;
+        this.encryption = encryption;
+        this.decryption = decryption;
+    }
+
+    private Health encryptionService;
+    private Health masterKey;
+    private Health dataKeyGenerator;
+    private Health encryption;
+    private Health decryption;
+
+    public Health getEncryptionService() {
+        return encryptionService;
+    }
+
+    public void setEncryptionService(Health encryptionService) {
+        this.encryptionService = encryptionService;
+    }
+
+    public Health getMasterKey() {
+        return masterKey;
+    }
+
+    public void setMasterKey(Health masterKey) {
+        this.masterKey = masterKey;
+    }
+
+    public Health getDataKeyGenerator() {
+        return dataKeyGenerator;
+    }
+
+    public void setDataKeyGenerator(Health dataKeyGenerator) {
+        this.dataKeyGenerator = dataKeyGenerator;
+    }
+
+    public Health getEncryption() {
+        return encryption;
+    }
+
+    public void setEncryption(Health encryption) {
+        this.encryption = encryption;
+    }
+
+    public Health getDecryption() {
+        return decryption;
+    }
+
+    public void setDecryption(Health decryption) {
+        this.decryption = decryption;
+    }
+
+}

--- a/src/main/java/uk/gov/dwp/dataworks/provider/CurrentKeyIdProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/CurrentKeyIdProvider.java
@@ -2,6 +2,6 @@ package uk.gov.dwp.dataworks.provider;
 
 import uk.gov.dwp.dataworks.errors.CurrentKeyIdException;
 
-public interface CurrentKeyIdProvider {
+public interface CurrentKeyIdProvider extends Dependent {
     String getKeyId() throws CurrentKeyIdException;
 }

--- a/src/main/java/uk/gov/dwp/dataworks/provider/DataKeyDecryptionProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/DataKeyDecryptionProvider.java
@@ -2,7 +2,7 @@ package uk.gov.dwp.dataworks.provider;
 
 import uk.gov.dwp.dataworks.dto.DecryptDataKeyResponse;
 
-public interface DataKeyDecryptionProvider {
+public interface DataKeyDecryptionProvider extends Dependent {
     int MAX_PAYLOAD_SIZE = 32000;
     DecryptDataKeyResponse decryptDataKey(String keyId, String ciphertextDataKey);
 }

--- a/src/main/java/uk/gov/dwp/dataworks/provider/DataKeyGeneratorProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/DataKeyGeneratorProvider.java
@@ -3,6 +3,7 @@ package uk.gov.dwp.dataworks.provider;
 import uk.gov.dwp.dataworks.dto.GenerateDataKeyResponse;
 import uk.gov.dwp.dataworks.errors.DataKeyGenerationException;
 
-public interface DataKeyGeneratorProvider {
+public interface DataKeyGeneratorProvider extends Dependent {
     GenerateDataKeyResponse generateDataKey(String keyId) throws DataKeyGenerationException;
+    boolean canSeeDependencies();
 }

--- a/src/main/java/uk/gov/dwp/dataworks/provider/Dependent.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/Dependent.java
@@ -1,0 +1,5 @@
+package uk.gov.dwp.dataworks.provider;
+
+public interface Dependent {
+    boolean canSeeDependencies();
+}

--- a/src/main/java/uk/gov/dwp/dataworks/provider/KMSCurrentKeyIdProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/KMSCurrentKeyIdProvider.java
@@ -35,4 +35,9 @@ public class KMSCurrentKeyIdProvider implements CurrentKeyIdProvider {
             throw new CurrentKeyIdException();
         }
     }
+
+    @Override
+    public boolean canSeeDependencies() {
+        return awsSimpleSystemsManagementClient != null;
+    }
 }

--- a/src/main/java/uk/gov/dwp/dataworks/provider/KMSDataKeyDecryptionProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/KMSDataKeyDecryptionProvider.java
@@ -60,4 +60,9 @@ public class KMSDataKeyDecryptionProvider implements DataKeyDecryptionProvider {
             throw new DataKeyDecryptionException();
         }
     }
+
+    @Override
+    public boolean canSeeDependencies() {
+        return awsKms != null;
+    }
 }

--- a/src/main/java/uk/gov/dwp/dataworks/provider/KMSDataKeyGeneratorProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/KMSDataKeyGeneratorProvider.java
@@ -38,4 +38,9 @@ public class KMSDataKeyGeneratorProvider implements DataKeyGeneratorProvider {
             throw new DataKeyGenerationException();
         }
     }
+
+    @Override
+    public boolean canSeeDependencies() {
+        return awsKms != null;
+    }
 }

--- a/src/main/java/uk/gov/dwp/dataworks/service/DataKeyService.java
+++ b/src/main/java/uk/gov/dwp/dataworks/service/DataKeyService.java
@@ -24,12 +24,21 @@ public class DataKeyService {
         this.dataKeyDecryptionProvider = dataKeyDecryptionProvider;
     }
 
+    public String currentKeyId() {
+        return currentKeyIdProvider.getKeyId();
+    }
+
     public GenerateDataKeyResponse generate() {
-        String keyEncryptionKeyId = currentKeyIdProvider.getKeyId();
-        return dataKeyProvider.generateDataKey(keyEncryptionKeyId);
+        return dataKeyProvider.generateDataKey(currentKeyId());
     }
 
     public DecryptDataKeyResponse decrypt(String dataKeyId, String ciphertextDataKey) {
         return dataKeyDecryptionProvider.decryptDataKey(dataKeyId, ciphertextDataKey);
+    }
+
+    public boolean canSeeDependencies() {
+        return dataKeyProvider != null && dataKeyProvider.canSeeDependencies() &&
+                currentKeyIdProvider != null && currentKeyIdProvider.canSeeDependencies() &&
+                dataKeyDecryptionProvider != null && dataKeyDecryptionProvider.canSeeDependencies();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,9 @@
 spring:
   profiles:
     active: KMS
+
+#server.port: 8443
+#server.ssl.key-store: rad/keystore.p12
+#server.ssl.key-store-password: Password1
+#server.ssl.keyStoreType: PKCS12
+#server.ssl.keyAlias: tomcat

--- a/src/test/java/uk/gov/dwp/dataworks/integration/DataKeyIntegrationTests.java
+++ b/src/test/java/uk/gov/dwp/dataworks/integration/DataKeyIntegrationTests.java
@@ -130,4 +130,5 @@ public class DataKeyIntegrationTests {
                 .andExpect(status().isBadRequest());
     }
 
+
 }

--- a/src/test/java/uk/gov/dwp/dataworks/integration/DataKeyIntegrationTests.java
+++ b/src/test/java/uk/gov/dwp/dataworks/integration/DataKeyIntegrationTests.java
@@ -129,6 +129,4 @@ public class DataKeyIntegrationTests {
                 .content("my garbled content to decrypt"))
                 .andExpect(status().isBadRequest());
     }
-
-
 }

--- a/src/test/java/uk/gov/dwp/dataworks/integration/HealthCheckIntegrationTests.java
+++ b/src/test/java/uk/gov/dwp/dataworks/integration/HealthCheckIntegrationTests.java
@@ -1,0 +1,224 @@
+package uk.gov.dwp.dataworks.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.dwp.dataworks.dto.DecryptDataKeyResponse;
+import uk.gov.dwp.dataworks.dto.GenerateDataKeyResponse;
+import uk.gov.dwp.dataworks.dto.HealthCheckResponse;
+import uk.gov.dwp.dataworks.provider.CurrentKeyIdProvider;
+import uk.gov.dwp.dataworks.provider.DataKeyDecryptionProvider;
+import uk.gov.dwp.dataworks.provider.DataKeyGeneratorProvider;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest()
+@ActiveProfiles("IntegrationTest")
+@AutoConfigureMockMvc
+public class HealthCheckIntegrationTests {
+
+    @Before
+    public void setup() {
+        Mockito.reset(currentKeyIdProvider, dataKeyGeneratorProvider, dataKeyDecryptionProvider);
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private CurrentKeyIdProvider currentKeyIdProvider;
+
+    @Autowired
+    private DataKeyGeneratorProvider dataKeyGeneratorProvider;
+
+    @Autowired
+    private DataKeyDecryptionProvider dataKeyDecryptionProvider;
+
+    private final static String HEALTHCHECK_ENDPOINT = "/healthcheck";
+    private final static String ENCRYPTION_KEY_ID = "ENCRYPTION_KEY_ID";
+    private final static String PLAIN_TEXT_KEY = "PLAIN_TEXT_KEY";
+    private final static String CIPHER_TEXT_DATA_KEY = "CIPHER_TEXT_DATA_KEY";
+
+    @Test
+    public void shouldGiveServerErrorCurrentKeyIdProviderDependencyCheckFails() throws Exception {
+        shouldGiveServerErrorWhenDependencyCheckFails(false,
+                true,
+                true);
+    }
+
+    @Test
+    public void shouldGiveServerErrorDataKeyGeneratorProviderDependencyCheckFails() throws Exception {
+        shouldGiveServerErrorWhenDependencyCheckFails(true,
+                false,
+                true);
+    }
+
+    @Test
+    public void shouldGiveServerErrorDataKeyDecryptionProviderDependencyCheckFails() throws Exception {
+        shouldGiveServerErrorWhenDependencyCheckFails(true,
+                true,
+                false);
+    }
+
+    private void shouldGiveServerErrorWhenDependencyCheckFails(
+            boolean currentKeyIdDependencies,
+            boolean dataKeyGeneratorDependencies,
+            boolean dataKeyDecryptionDependencies) throws Exception {
+        given(currentKeyIdProvider.canSeeDependencies()).willReturn(currentKeyIdDependencies);
+        given(dataKeyGeneratorProvider.canSeeDependencies()).willReturn(dataKeyGeneratorDependencies);
+        given(dataKeyDecryptionProvider.canSeeDependencies()).willReturn(dataKeyDecryptionDependencies);
+        HealthCheckResponse healthCheckResponse = new HealthCheckResponse(HealthCheckResponse.Health.BAD,
+                HealthCheckResponse.Health.BAD,
+                HealthCheckResponse.Health.BAD,
+                HealthCheckResponse.Health.BAD,
+                HealthCheckResponse.Health.BAD);
+        mockMvc.perform(get(HEALTHCHECK_ENDPOINT))
+                .andExpect(content().json(new ObjectMapper().writeValueAsString(healthCheckResponse)))
+                .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    public void shouldGiveServerErrorWhenMasterKeyCheckFails() throws Exception {
+        given(currentKeyIdProvider.canSeeDependencies()).willReturn(true);
+        given(dataKeyGeneratorProvider.canSeeDependencies()).willReturn(true);
+        given(dataKeyDecryptionProvider.canSeeDependencies()).willReturn(true);
+        given(currentKeyIdProvider.getKeyId()).willThrow(RuntimeException.class);
+
+        HealthCheckResponse healthCheckResponse = new HealthCheckResponse(HealthCheckResponse.Health.OK,
+                HealthCheckResponse.Health.BAD,
+                HealthCheckResponse.Health.BAD,
+                HealthCheckResponse.Health.BAD,
+                HealthCheckResponse.Health.BAD);
+        mockMvc.perform(get(HEALTHCHECK_ENDPOINT))
+                .andExpect(content().json(new ObjectMapper().writeValueAsString(healthCheckResponse)))
+                .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    public void shouldGiveServerErrorWhenMasterKeyCheckGivesEmptyKey() throws Exception {
+        given(currentKeyIdProvider.canSeeDependencies()).willReturn(true);
+        given(dataKeyGeneratorProvider.canSeeDependencies()).willReturn(true);
+        given(dataKeyDecryptionProvider.canSeeDependencies()).willReturn(true);
+        given(currentKeyIdProvider.getKeyId()).willReturn("");
+        HealthCheckResponse healthCheckResponse = new HealthCheckResponse(HealthCheckResponse.Health.OK,
+                HealthCheckResponse.Health.BAD,
+                HealthCheckResponse.Health.BAD,
+                HealthCheckResponse.Health.BAD,
+                HealthCheckResponse.Health.BAD);
+        mockMvc.perform(get(HEALTHCHECK_ENDPOINT))
+                .andExpect(content().json(new ObjectMapper().writeValueAsString(healthCheckResponse)))
+                .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    public void shouldGiveServerErrorWhenGenerateKeyFails() throws Exception {
+        given(currentKeyIdProvider.canSeeDependencies()).willReturn(true);
+        given(dataKeyGeneratorProvider.canSeeDependencies()).willReturn(true);
+        given(dataKeyDecryptionProvider.canSeeDependencies()).willReturn(true);
+        given(currentKeyIdProvider.getKeyId()).willReturn(ENCRYPTION_KEY_ID);
+        given(dataKeyGeneratorProvider.generateDataKey(ENCRYPTION_KEY_ID)).willThrow(RuntimeException.class);
+
+        HealthCheckResponse healthCheckResponse = new HealthCheckResponse(HealthCheckResponse.Health.OK,
+                HealthCheckResponse.Health.OK,
+                HealthCheckResponse.Health.BAD,
+                HealthCheckResponse.Health.BAD,
+                HealthCheckResponse.Health.BAD);
+
+        mockMvc.perform(get(HEALTHCHECK_ENDPOINT))
+                .andExpect(content().json(new ObjectMapper().writeValueAsString(healthCheckResponse)))
+                .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    public void shouldGiveServerErrorWhenDecryptionFails() throws Exception {
+        given(currentKeyIdProvider.canSeeDependencies()).willReturn(true);
+        given(dataKeyGeneratorProvider.canSeeDependencies()).willReturn(true);
+        given(dataKeyDecryptionProvider.canSeeDependencies()).willReturn(true);
+        given(currentKeyIdProvider.getKeyId()).willReturn(ENCRYPTION_KEY_ID);
+        GenerateDataKeyResponse response =
+                new GenerateDataKeyResponse(ENCRYPTION_KEY_ID, PLAIN_TEXT_KEY, CIPHER_TEXT_DATA_KEY);
+
+        given(dataKeyGeneratorProvider.generateDataKey(ENCRYPTION_KEY_ID)).willReturn(response);
+
+        given(dataKeyDecryptionProvider.decryptDataKey(ENCRYPTION_KEY_ID, CIPHER_TEXT_DATA_KEY))
+                .willThrow(RuntimeException.class);
+
+        HealthCheckResponse healthCheckResponse = new HealthCheckResponse(HealthCheckResponse.Health.OK,
+                HealthCheckResponse.Health.OK,
+                HealthCheckResponse.Health.OK,
+                HealthCheckResponse.Health.OK,
+                HealthCheckResponse.Health.BAD);
+
+        mockMvc.perform(get(HEALTHCHECK_ENDPOINT))
+                .andExpect(content().json(new ObjectMapper().writeValueAsString(healthCheckResponse)))
+                .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    public void shouldGiveServerErrorWhenDecryptedKeyDoesntMatch() throws Exception {
+        given(currentKeyIdProvider.canSeeDependencies()).willReturn(true);
+        given(dataKeyGeneratorProvider.canSeeDependencies()).willReturn(true);
+        given(dataKeyDecryptionProvider.canSeeDependencies()).willReturn(true);
+        given(currentKeyIdProvider.getKeyId()).willReturn(ENCRYPTION_KEY_ID);
+        GenerateDataKeyResponse response =
+                new GenerateDataKeyResponse(ENCRYPTION_KEY_ID, PLAIN_TEXT_KEY, CIPHER_TEXT_DATA_KEY);
+
+        given(dataKeyGeneratorProvider.generateDataKey(ENCRYPTION_KEY_ID)).willReturn(response);
+
+        DecryptDataKeyResponse decryptResponse = new DecryptDataKeyResponse(ENCRYPTION_KEY_ID, PLAIN_TEXT_KEY);
+
+        given(dataKeyDecryptionProvider.decryptDataKey(ENCRYPTION_KEY_ID, CIPHER_TEXT_DATA_KEY + "_CHANGE"))
+                .willReturn(decryptResponse);
+
+        HealthCheckResponse healthCheckResponse = new HealthCheckResponse(HealthCheckResponse.Health.OK,
+                HealthCheckResponse.Health.OK,
+                HealthCheckResponse.Health.OK,
+                HealthCheckResponse.Health.OK,
+                HealthCheckResponse.Health.BAD);
+
+        mockMvc.perform(get(HEALTHCHECK_ENDPOINT))
+                .andExpect(content().json(new ObjectMapper().writeValueAsString(healthCheckResponse)))
+                .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    public void shouldReturnStatusOkWhenAllChecksPass() throws Exception {
+
+        given(currentKeyIdProvider.canSeeDependencies()).willReturn(true);
+        given(dataKeyGeneratorProvider.canSeeDependencies()).willReturn(true);
+        given(dataKeyDecryptionProvider.canSeeDependencies()).willReturn(true);
+        given(currentKeyIdProvider.getKeyId()).willReturn(ENCRYPTION_KEY_ID);
+
+        GenerateDataKeyResponse response =
+                new GenerateDataKeyResponse(ENCRYPTION_KEY_ID, PLAIN_TEXT_KEY, CIPHER_TEXT_DATA_KEY);
+
+        given(dataKeyGeneratorProvider.generateDataKey(ENCRYPTION_KEY_ID)).willReturn(response);
+        DecryptDataKeyResponse decryptResponse = new DecryptDataKeyResponse(ENCRYPTION_KEY_ID, PLAIN_TEXT_KEY);
+
+        given(dataKeyDecryptionProvider.decryptDataKey(ENCRYPTION_KEY_ID, CIPHER_TEXT_DATA_KEY))
+                .willReturn(decryptResponse);
+
+        HealthCheckResponse healthCheckResponse = new HealthCheckResponse(HealthCheckResponse.Health.OK,
+                HealthCheckResponse.Health.OK,
+                HealthCheckResponse.Health.OK,
+                HealthCheckResponse.Health.OK,
+                HealthCheckResponse.Health.OK);
+
+        mockMvc.perform(get(HEALTHCHECK_ENDPOINT))
+                .andExpect(content().json(new ObjectMapper().writeValueAsString(healthCheckResponse)))
+                .andExpect(status().isOk());
+    }
+
+}


### PR DESCRIPTION
New GET endpoint on ‘/healthcheck’ reports the following

- all dependencies can be reached,
- the current master key id can be fetched,
- a new key can be generated,
- the new key is encrypted
- the new key can be decrypted

Response code is 200 if everything is OK, 500 otherwise. Example response body:

{
  "encryptionService": "OK",
  "masterKey": "OK",
  "dataKeyGenerator": "OK",
  "encryption": "OK",
  "decryption": “BAD”
}