### PR TITLE
Parameter store entry is now named 'data_key_service.currentKeyId'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Response code is 200 if everything is OK, 500 otherwise. Example response body:
 ## Infrastructure 
 * KMS CMK (Master Key), (enabled)
 * Parameter Store parameter 
-  * named ```data-key-service.currentKeyId```
+  * named ```data_key_service.currentKeyId```
   * value set to the full ARN for the KMS master key
 * AWS user must have permissions for:
   * ```ssm:GetParameter``` on the Parameter store parameter

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 apply plugin: 'io.spring.dependency-management'
 
 group = 'uk.gov.dwp.dataworks'
-version = '0.0.1-SNAPSHOT'
+version = '0.0.9-SNAPSHOT'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -9,7 +9,7 @@
 ## Infrastructure 
 * KMS CMK (Master Key), (enabled)
 * Parameter Store parameter 
-  * named ```data-key-service.currentKeyId```
+  * named ```data_key_service.currentKeyId```
   * value set to the full ARN for the KMS master key
 * AWS user must have permissions for:
   * ```ssm:GetParameter``` on the Parameter store parameter

--- a/src/main/java/uk/gov/dwp/dataworks/provider/KMSCurrentKeyIdProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/KMSCurrentKeyIdProvider.java
@@ -25,7 +25,7 @@ public class KMSCurrentKeyIdProvider implements CurrentKeyIdProvider {
     public String getKeyId() throws CurrentKeyIdException {
         try {
             GetParameterRequest request = new GetParameterRequest()
-                    .withName("data-key-service.currentKeyId")
+                    .withName("data_key_service.currentKeyId")
                     .withWithDecryption(false);
             GetParameterResult result = awsSimpleSystemsManagementClient.getParameter(request);
             return result.getParameter().getValue();

--- a/src/test/java/uk/gov/dwp/dataworks/provider/KMSCurrentKeyIdProviderTest.java
+++ b/src/test/java/uk/gov/dwp/dataworks/provider/KMSCurrentKeyIdProviderTest.java
@@ -102,7 +102,7 @@ public class KMSCurrentKeyIdProviderTest {
     }
 
     private GetParameterRequest getGetParameterRequest() {
-        return new GetParameterRequest().withName("data-key-service.currentKeyId").withWithDecryption(false);
+        return new GetParameterRequest().withName("data_key_service.currentKeyId").withWithDecryption(false);
     }
 
     @Autowired


### PR DESCRIPTION
This is the requested change to the name of parameter store entry that holds the id of the CMK.