### PR TITLE
DW-2387 - New Healthcheck polling service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ out/
 #Logs
 dks.log.directory_IS_UNDEFINED
 dks.log.*
+logs/
+*.log
 *.jks
 *.pem
 *.crt

--- a/src/main/java/uk/gov/dwp/dataworks/config/SchedulingConfiguration.java
+++ b/src/main/java/uk/gov/dwp/dataworks/config/SchedulingConfiguration.java
@@ -1,0 +1,9 @@
+package uk.gov.dwp.dataworks.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfiguration {
+}

--- a/src/main/java/uk/gov/dwp/dataworks/dto/HealthCheckResponse.java
+++ b/src/main/java/uk/gov/dwp/dataworks/dto/HealthCheckResponse.java
@@ -47,6 +47,14 @@ public class HealthCheckResponse {
         this.trustedCertificates = new HashMap<>();
     }
 
+    public boolean areAllServicesOk() {
+        return encryptionService == Health.OK
+                && masterKey == Health.OK
+                && dataKeyGenerator == Health.OK
+                && encryption == Health.OK
+                && decryption == Health.OK;
+    }
+
     public Health getEncryptionService() {
         return encryptionService;
     }

--- a/src/main/java/uk/gov/dwp/dataworks/service/HealthCheckService.java
+++ b/src/main/java/uk/gov/dwp/dataworks/service/HealthCheckService.java
@@ -1,0 +1,50 @@
+package uk.gov.dwp.dataworks.service;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.MappingJsonFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import uk.gov.dwp.dataworks.controller.HealthCheckController;
+import uk.gov.dwp.dataworks.dto.DecryptDataKeyResponse;
+import uk.gov.dwp.dataworks.dto.GenerateDataKeyResponse;
+import uk.gov.dwp.dataworks.dto.HealthCheckResponse;
+import uk.gov.dwp.dataworks.errors.LoginException;
+import uk.gov.dwp.dataworks.provider.CurrentKeyIdProvider;
+import uk.gov.dwp.dataworks.provider.DataKeyDecryptionProvider;
+import uk.gov.dwp.dataworks.provider.DataKeyGeneratorProvider;
+
+@Service
+public class HealthCheckService {
+    private final HealthCheckController healthCheckController;
+    private final static Logger LOGGER = LoggerFactory.getLogger("healthcheck");
+
+    @Autowired
+    public HealthCheckService(HealthCheckController healthCheckController) {
+        this.healthCheckController = healthCheckController;
+    }
+
+    @Scheduled(initialDelay = 1000, fixedRateString = "${healthcheck.interval:6000}")
+    public void logHealthCheck() throws JsonProcessingException {
+        ResponseEntity<HealthCheckResponse> response = healthCheckController.healthCheck();
+
+        JsonFactory factory = new MappingJsonFactory();
+        ObjectMapper mapper = new ObjectMapper(factory);
+        ObjectNode responseBody = mapper.valueToTree(response.getBody());
+        responseBody.remove("trustedCertificates");
+        if(response.getStatusCode().value() == 200) {
+            LOGGER.info("HEALTHCHECK: {}", responseBody);
+        }
+        else {
+            LOGGER.warn("HEALTHCHECK {}", responseBody);
+        }
+    }
+}

--- a/src/main/java/uk/gov/dwp/dataworks/service/HealthCheckService.java
+++ b/src/main/java/uk/gov/dwp/dataworks/service/HealthCheckService.java
@@ -8,21 +8,15 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import uk.gov.dwp.dataworks.controller.HealthCheckController;
-import uk.gov.dwp.dataworks.dto.DecryptDataKeyResponse;
-import uk.gov.dwp.dataworks.dto.GenerateDataKeyResponse;
 import uk.gov.dwp.dataworks.dto.HealthCheckResponse;
-import uk.gov.dwp.dataworks.errors.LoginException;
-import uk.gov.dwp.dataworks.provider.CurrentKeyIdProvider;
-import uk.gov.dwp.dataworks.provider.DataKeyDecryptionProvider;
-import uk.gov.dwp.dataworks.provider.DataKeyGeneratorProvider;
 
 @Service
+@ConditionalOnProperty(value = "scheduling.enabled", havingValue = "true", matchIfMissing = true)
 public class HealthCheckService {
     private final HealthCheckController healthCheckController;
     private final static Logger LOGGER = LoggerFactory.getLogger("healthcheck");

--- a/src/test/java/uk/gov/dwp/dataworks/services/DataKeyServiceTest.java
+++ b/src/test/java/uk/gov/dwp/dataworks/services/DataKeyServiceTest.java
@@ -19,7 +19,8 @@ import uk.gov.dwp.dataworks.service.DataKeyService;
 @SpringBootTest
 @TestPropertySource(properties = {"server.environment_name=development",
         "cache.eviction.interval=1000",
-        "key.cache.eviction.interval=1000"
+        "key.cache.eviction.interval=1000",
+        "scheduling.enabled=false"
 })
 public class DataKeyServiceTest {
 
@@ -50,7 +51,6 @@ public class DataKeyServiceTest {
         Thread.sleep(2000);
         dataKeyService.currentKeyId();
         // Verification
-        Mockito.verify(currentKeyIdProvider, Mockito.times(2)).getKeyId();
         Mockito.verify(currentKeyIdProvider, Mockito.times(2)).getKeyId();
     }
 

--- a/src/test/java/uk/gov/dwp/dataworks/services/HealthCheckServiceTest.java
+++ b/src/test/java/uk/gov/dwp/dataworks/services/HealthCheckServiceTest.java
@@ -1,0 +1,60 @@
+package uk.gov.dwp.dataworks.services;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cache.CacheManager;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.dwp.dataworks.controller.HealthCheckController;
+import uk.gov.dwp.dataworks.dto.HealthCheckResponse;
+import uk.gov.dwp.dataworks.provider.CurrentKeyIdProvider;
+import uk.gov.dwp.dataworks.provider.DataKeyDecryptionProvider;
+import uk.gov.dwp.dataworks.provider.DataKeyGeneratorProvider;
+import uk.gov.dwp.dataworks.service.DataKeyService;
+import uk.gov.dwp.dataworks.service.HealthCheckService;
+
+import static uk.gov.dwp.dataworks.dto.HealthCheckResponse.Health.OK;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@TestPropertySource(properties = {"healthcheck.interval=1000"})
+public class HealthCheckServiceTest {
+
+    private ResponseEntity<HealthCheckResponse> mockHealthOkResponse = org.springframework.http.ResponseEntity.ok(new HealthCheckResponse(OK, OK, OK, OK, OK));
+
+    @Autowired
+    private HealthCheckService healthCheckService;
+
+    @MockBean
+    private HealthCheckController healthCheckController;
+
+    @MockBean
+    private DataKeyGeneratorProvider dataKeyGeneratorProvider;
+
+    @MockBean
+    private CurrentKeyIdProvider currentKeyIdProvider;
+
+    @MockBean
+    private DataKeyDecryptionProvider dataKeyDecryptionProvider;
+
+    @Test
+    public void Should_Run_Healthcheck_Initially_After_One_Second() throws InterruptedException  {
+        Mockito.when(healthCheckController.healthCheck()).thenReturn(mockHealthOkResponse);
+        Thread.sleep(1000);
+        Mockito.verify(healthCheckController, Mockito.times(1)).healthCheck();
+    }
+
+    @Test
+    public void Should_Run_Healthcheck_At_Specified_Interval() throws InterruptedException {
+        Mockito.when(healthCheckController.healthCheck()).thenReturn(mockHealthOkResponse);
+        Thread.sleep(3000);
+        Mockito.verify(healthCheckController, Mockito.times(3)).healthCheck();
+    }
+}

--- a/src/test/java/uk/gov/dwp/dataworks/services/HealthCheckServiceTest.java
+++ b/src/test/java/uk/gov/dwp/dataworks/services/HealthCheckServiceTest.java
@@ -24,7 +24,7 @@ import static uk.gov.dwp.dataworks.dto.HealthCheckResponse.Health.OK;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
-@TestPropertySource(properties = {"healthcheck.interval=1000"})
+@TestPropertySource(properties = {"healthcheck.interval=1000", "scheduling.enabled=true"})
 public class HealthCheckServiceTest {
 
     private ResponseEntity<HealthCheckResponse> mockHealthOkResponse = org.springframework.http.ResponseEntity.ok(new HealthCheckResponse(OK, OK, OK, OK, OK));

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -9,7 +9,7 @@
     </appender>
 
     <appender name="HEALTHCHECK-FILE" class="ch.qos.logback.core.FileAppender">
-        <file>/var/logs/dks/healthcheck.log</file>
+        <file>logs/healthcheck.log</file>
         <append>true</append>
         <encoder>
             <pattern>[%d{yyyy-MM-dd HH:mm:ss}] [%level] [%file:%method:%line] %message%n</pattern>


### PR DESCRIPTION
Adding a new service which will poll the /healthcheck endpoint at a configured time interval and log that to a healthcheck.log file