### PR TITLE
DW-3354 add client correlation id

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,32 @@ DataWorks service to manage the generation and decryption of data keys.
   * See versions in See https://docs.aws.amazon.com/cloudhsm/latest/userguide/client-history.html
   * Must match those used in aws infrastructure
 
+## On a unix machine
+Follow the instructions on the AWS link above:
+```bash
+wget https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL6/cloudhsm-client-jce-latest.el6.x86_64.rpm
+sudo yum install -y ./cloudhsm-client-jce-latest.el6.x86_64.rpm
+```
+or
+```bash
+wget https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/Xenial/cloudhsm-client-jce_latest_amd64.deb
+sudo dpkg -i cloudhsm-client-jce_latest_amd64.deb
+```
+
+## On a Mac
+You need to get the rpm, extract the files, and put them in the right place yourself
+```bash
+brew install wget
+wget https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL6/cloudhsm-client-jce-latest.el6.x86_64.rpm
+tar -xvzf cloudhsm-client-jce-latest.el6.x86_64.rpm
+cp -R opt/cloudhsm /opt/cloudhsm/
+chmod -R a+rwx /opt/cloudhsm
+```
+You can also use other mac utilities like `rpm2cpio`:
+```bash
+rpm2cpio cloudhsm-client-jce-latest.el6.x86_64.rpm | cpio -i -d 
+```
+
 # Build instructions
 Gradle will fetch required packages and action all of the building. You can start the process by using the gradle wrapper
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,6 @@
-#Wed Apr 10 09:08:09 BST 2019
+#Mon Jan 27 15:04:45 GMT 2020
+distributionUrl=https\://downloads.gradle.org/distributions/gradle-5.5.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-#distributionUrl=https://nexus3.ucds.io/repository/thirdparty/org/gradle/distributions/gradle/5.5.1/gradle-5.5.1-bin.zip
-distributionUrl=https://downloads.gradle.org/distributions/gradle-5.5.1-bin.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/uk/gov/dwp/dataworks/controller/DataKeyController.java
+++ b/src/main/java/uk/gov/dwp/dataworks/controller/DataKeyController.java
@@ -33,9 +33,9 @@ public class DataKeyController {
             @ApiResponse(code = 503, message = "There has been an internal error, or a dependency failure")
     })
     public ResponseEntity<GenerateDataKeyResponse> generate(
-            @RequestParam(name = "dksCorrelationId", defaultValue = "NOT_SET") String dksCorrelationId) throws MasterKeystoreException {
-        String keyId = dataKeyService.currentKeyId(dksCorrelationId);
-        return new ResponseEntity<>(dataKeyService.generate(keyId, dksCorrelationId), HttpStatus.CREATED);
+            @RequestParam(name = "correlationId", defaultValue = "NOT_SET") String correlationId) throws MasterKeystoreException {
+        String keyId = dataKeyService.currentKeyId(correlationId);
+        return new ResponseEntity<>(dataKeyService.generate(keyId, correlationId), HttpStatus.CREATED);
     }
 
     @RequestMapping(value = "/actions/decrypt", method = RequestMethod.POST)
@@ -47,9 +47,9 @@ public class DataKeyController {
     })
     public DecryptDataKeyResponse decrypt(
             @RequestParam(name = "keyId") String dataKeyEncryptionKeyId,
-            @RequestParam(name = "dksCorrelationId", defaultValue = "NOT_SET") String dksCorrelationId,
+            @RequestParam(name = "correlationId", defaultValue = "NOT_SET") String correlationId,
             @RequestBody String ciphertextDataKey) throws MasterKeystoreException {
-        return dataKeyService.decrypt(dataKeyEncryptionKeyId, ciphertextDataKey, dksCorrelationId);
+        return dataKeyService.decrypt(dataKeyEncryptionKeyId, ciphertextDataKey, correlationId);
     }
 
 }

--- a/src/main/java/uk/gov/dwp/dataworks/controller/DataKeyController.java
+++ b/src/main/java/uk/gov/dwp/dataworks/controller/DataKeyController.java
@@ -34,7 +34,8 @@ public class DataKeyController {
     })
     public ResponseEntity<GenerateDataKeyResponse> generate(
             @RequestParam(name = "dksCorrelationId", defaultValue = "NOT_SET") String dksCorrelationId) throws MasterKeystoreException {
-        return new ResponseEntity<>(dataKeyService.generate(dataKeyService.currentKeyId(dksCorrelationId), dksCorrelationId), HttpStatus.CREATED);
+        String keyId = dataKeyService.currentKeyId(dksCorrelationId);
+        return new ResponseEntity<>(dataKeyService.generate(keyId, dksCorrelationId), HttpStatus.CREATED);
     }
 
     @RequestMapping(value = "/actions/decrypt", method = RequestMethod.POST)

--- a/src/main/java/uk/gov/dwp/dataworks/controller/DataKeyController.java
+++ b/src/main/java/uk/gov/dwp/dataworks/controller/DataKeyController.java
@@ -34,7 +34,7 @@ public class DataKeyController {
     })
     public ResponseEntity<GenerateDataKeyResponse> generate(
             @RequestParam(name = "dksCorrelationId", defaultValue = "NOT_SET") String dksCorrelationId) throws MasterKeystoreException {
-        return new ResponseEntity<>(dataKeyService.generate(dataKeyService.currentKeyId(), dksCorrelationId), HttpStatus.CREATED);
+        return new ResponseEntity<>(dataKeyService.generate(dataKeyService.currentKeyId(dksCorrelationId), dksCorrelationId), HttpStatus.CREATED);
     }
 
     @RequestMapping(value = "/actions/decrypt", method = RequestMethod.POST)

--- a/src/main/java/uk/gov/dwp/dataworks/controller/DataKeyController.java
+++ b/src/main/java/uk/gov/dwp/dataworks/controller/DataKeyController.java
@@ -34,7 +34,7 @@ public class DataKeyController {
     })
     public ResponseEntity<GenerateDataKeyResponse> generate(
             @RequestParam(name = "dksCorrelationId", defaultValue = "NOT_SET") String dksCorrelationId) throws MasterKeystoreException {
-        return new ResponseEntity<>(dataKeyService.generate(dataKeyService.currentKeyId()), HttpStatus.CREATED);
+        return new ResponseEntity<>(dataKeyService.generate(dataKeyService.currentKeyId(), dksCorrelationId), HttpStatus.CREATED);
     }
 
     @RequestMapping(value = "/actions/decrypt", method = RequestMethod.POST)
@@ -48,7 +48,7 @@ public class DataKeyController {
             @RequestParam(name = "keyId") String dataKeyEncryptionKeyId,
             @RequestParam(name = "dksCorrelationId", defaultValue = "NOT_SET") String dksCorrelationId,
             @RequestBody String ciphertextDataKey) throws MasterKeystoreException {
-        return dataKeyService.decrypt(dataKeyEncryptionKeyId, ciphertextDataKey);
+        return dataKeyService.decrypt(dataKeyEncryptionKeyId, ciphertextDataKey, dksCorrelationId);
     }
 
 }

--- a/src/main/java/uk/gov/dwp/dataworks/controller/DataKeyController.java
+++ b/src/main/java/uk/gov/dwp/dataworks/controller/DataKeyController.java
@@ -16,7 +16,7 @@ import uk.gov.dwp.dataworks.service.DataKeyService;
 @SuppressWarnings("unused")
 @RestController
 @RequestMapping("/datakey")
-@Api(value="datakey")
+@Api(value = "datakey")
 public class DataKeyController {
 
     private final DataKeyService dataKeyService;
@@ -27,26 +27,28 @@ public class DataKeyController {
     }
 
     @RequestMapping(value = "", method = RequestMethod.GET)
-    @ApiOperation(value="Generate a new data key", response=GenerateDataKeyResponse.class)
+    @ApiOperation(value = "Generate a new data key", response = GenerateDataKeyResponse.class)
     @ApiResponses(value = {
             @ApiResponse(code = 201, message = "Successfully created a new data key"),
             @ApiResponse(code = 503, message = "There has been an internal error, or a dependency failure")
     })
-    public ResponseEntity<GenerateDataKeyResponse> generate() throws MasterKeystoreException {
+    public ResponseEntity<GenerateDataKeyResponse> generate(
+            @RequestParam(name = "dksCorrelationId", defaultValue = "NOT_SET") String dksCorrelationId) throws MasterKeystoreException {
         return new ResponseEntity<>(dataKeyService.generate(dataKeyService.currentKeyId()), HttpStatus.CREATED);
     }
 
     @RequestMapping(value = "/actions/decrypt", method = RequestMethod.POST)
-    @ApiOperation(value="Tries to decrypt the ciphertext of a data key", response=DecryptDataKeyResponse.class)
+    @ApiOperation(value = "Tries to decrypt the ciphertext of a data key", response = DecryptDataKeyResponse.class)
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Successfully decrypted the data key"),
             @ApiResponse(code = 400, message = "The supplied data key could not be decrypted. Either the ciphertext is invalid or the data key encryption key is incorrect."),
             @ApiResponse(code = 503, message = "There has been an internal error, or a dependency failure")
-    })    public DecryptDataKeyResponse decrypt(
-            @RequestParam(value = "keyId") String dataKeyEncryptionKeyId,
+    })
+    public DecryptDataKeyResponse decrypt(
+            @RequestParam(name = "keyId") String dataKeyEncryptionKeyId,
+            @RequestParam(name = "dksCorrelationId", defaultValue = "NOT_SET") String dksCorrelationId,
             @RequestBody String ciphertextDataKey) throws MasterKeystoreException {
         return dataKeyService.decrypt(dataKeyEncryptionKeyId, ciphertextDataKey);
     }
-
 
 }

--- a/src/main/java/uk/gov/dwp/dataworks/controller/HealthCheckController.java
+++ b/src/main/java/uk/gov/dwp/dataworks/controller/HealthCheckController.java
@@ -63,7 +63,7 @@ public class HealthCheckController {
         boolean canCreateNewDataKey = false;
         boolean canEncryptDataKey = false;
         boolean canDecryptDataKey = false;
-        HealthCheckResponse health = new HealthCheckResponse().withcorrelationId(correlationId);
+        HealthCheckResponse health = new HealthCheckResponse().withCorrelationId(correlationId);
         try {
             Map<String, String> trustedCertificates = new HashMap<>();
 

--- a/src/main/java/uk/gov/dwp/dataworks/controller/HealthCheckController.java
+++ b/src/main/java/uk/gov/dwp/dataworks/controller/HealthCheckController.java
@@ -56,8 +56,6 @@ public class HealthCheckController {
     })
 
     public ResponseEntity<HealthCheckResponse> healthCheck() {
-
-
         boolean canReachDependencies = false;
         boolean canRetrieveCurrentMasterKeyId = false;
         boolean canCreateNewDataKey = false;

--- a/src/main/java/uk/gov/dwp/dataworks/controller/HealthCheckController.java
+++ b/src/main/java/uk/gov/dwp/dataworks/controller/HealthCheckController.java
@@ -57,13 +57,13 @@ public class HealthCheckController {
     })
 
     public ResponseEntity<HealthCheckResponse> healthCheck(
-            @RequestParam(name = "dksCorrelationId", defaultValue = "NOT_SET") String dksCorrelationId) {
+            @RequestParam(name = "correlationId", defaultValue = "NOT_SET") String correlationId) {
         boolean canReachDependencies = false;
         boolean canRetrieveCurrentMasterKeyId = false;
         boolean canCreateNewDataKey = false;
         boolean canEncryptDataKey = false;
         boolean canDecryptDataKey = false;
-        HealthCheckResponse health = new HealthCheckResponse().withDksCorrelationId(dksCorrelationId);
+        HealthCheckResponse health = new HealthCheckResponse().withcorrelationId(correlationId);
         try {
             Map<String, String> trustedCertificates = new HashMap<>();
 
@@ -81,15 +81,15 @@ public class HealthCheckController {
 
             health.setTrustedCertificates(trustedCertificates);
             canReachDependencies = dataKeyService != null && dataKeyService.canSeeDependencies();
-            String currentKeyId = Objects.requireNonNull(this.dataKeyService).currentKeyId(dksCorrelationId);
+            String currentKeyId = Objects.requireNonNull(this.dataKeyService).currentKeyId(correlationId);
             canRetrieveCurrentMasterKeyId = ! Strings.isNullOrEmpty(currentKeyId);
-            String keyId = dataKeyService.currentKeyId(dksCorrelationId);
-            GenerateDataKeyResponse encryptResponse = dataKeyService.generate(keyId, dksCorrelationId);
+            String keyId = dataKeyService.currentKeyId(correlationId);
+            GenerateDataKeyResponse encryptResponse = dataKeyService.generate(keyId, correlationId);
             canCreateNewDataKey = ! Strings.isNullOrEmpty(encryptResponse.dataKeyEncryptionKeyId) &&
                                     ! Strings.isNullOrEmpty(encryptResponse.plaintextDataKey);
             canEncryptDataKey = ! Strings.isNullOrEmpty(encryptResponse.ciphertextDataKey);
             DecryptDataKeyResponse decryptResponse =
-                    dataKeyService.decrypt(encryptResponse.dataKeyEncryptionKeyId, encryptResponse.ciphertextDataKey, dksCorrelationId);
+                    dataKeyService.decrypt(encryptResponse.dataKeyEncryptionKeyId, encryptResponse.ciphertextDataKey, correlationId);
             canDecryptDataKey = ! Strings.isNullOrEmpty(decryptResponse.plaintextDataKey) &&
                     decryptResponse.plaintextDataKey.equals(encryptResponse.plaintextDataKey);
         }

--- a/src/main/java/uk/gov/dwp/dataworks/controller/HealthCheckController.java
+++ b/src/main/java/uk/gov/dwp/dataworks/controller/HealthCheckController.java
@@ -63,7 +63,7 @@ public class HealthCheckController {
         boolean canCreateNewDataKey = false;
         boolean canEncryptDataKey = false;
         boolean canDecryptDataKey = false;
-        HealthCheckResponse health = new HealthCheckResponse();
+        HealthCheckResponse health = new HealthCheckResponse().withDksCorrelationId(dksCorrelationId);
         try {
             Map<String, String> trustedCertificates = new HashMap<>();
 

--- a/src/main/java/uk/gov/dwp/dataworks/controller/HealthCheckController.java
+++ b/src/main/java/uk/gov/dwp/dataworks/controller/HealthCheckController.java
@@ -81,9 +81,10 @@ public class HealthCheckController {
 
             health.setTrustedCertificates(trustedCertificates);
             canReachDependencies = dataKeyService != null && dataKeyService.canSeeDependencies();
-            String currentKeyId = Objects.requireNonNull(this.dataKeyService).currentKeyId();
+            String currentKeyId = Objects.requireNonNull(this.dataKeyService).currentKeyId(dksCorrelationId);
             canRetrieveCurrentMasterKeyId = ! Strings.isNullOrEmpty(currentKeyId);
-            GenerateDataKeyResponse encryptResponse = dataKeyService.generate(dataKeyService.currentKeyId(), dksCorrelationId);
+            String keyId = dataKeyService.currentKeyId(dksCorrelationId);
+            GenerateDataKeyResponse encryptResponse = dataKeyService.generate(keyId, dksCorrelationId);
             canCreateNewDataKey = ! Strings.isNullOrEmpty(encryptResponse.dataKeyEncryptionKeyId) &&
                                     ! Strings.isNullOrEmpty(encryptResponse.plaintextDataKey);
             canEncryptDataKey = ! Strings.isNullOrEmpty(encryptResponse.ciphertextDataKey);

--- a/src/main/java/uk/gov/dwp/dataworks/dto/DecryptDataKeyResponse.java
+++ b/src/main/java/uk/gov/dwp/dataworks/dto/DecryptDataKeyResponse.java
@@ -21,15 +21,15 @@ public class DecryptDataKeyResponse {
         this.plaintextDataKey = plaintextDataKey;
     }
 
-    public String getcorrelationId() {
+    public String getCorrelationId() {
         return correlationId;
     }
 
-    public void setcorrelationId(String correlationId) {
+    public void setCorrelationId(String correlationId) {
         this.correlationId = correlationId;
     }
 
-    public DecryptDataKeyResponse withcorrelationId(String correlationId) {
+    public DecryptDataKeyResponse withCorrelationId(String correlationId) {
         this.correlationId = correlationId;
         return this;
     }

--- a/src/main/java/uk/gov/dwp/dataworks/dto/DecryptDataKeyResponse.java
+++ b/src/main/java/uk/gov/dwp/dataworks/dto/DecryptDataKeyResponse.java
@@ -14,23 +14,23 @@ public class DecryptDataKeyResponse {
     public final String plaintextDataKey;
 
     @ApiModelProperty(notes="DKS Correlation Id passed in from the client call")
-    public String dksCorrelationId = "NOT_SET";
+    public String correlationId = "NOT_SET";
 
     public DecryptDataKeyResponse(String dataKeyDecryptionKeyId, String plaintextDataKey) {
         this.dataKeyDecryptionKeyId = dataKeyDecryptionKeyId;
         this.plaintextDataKey = plaintextDataKey;
     }
 
-    public String getDksCorrelationId() {
-        return dksCorrelationId;
+    public String getcorrelationId() {
+        return correlationId;
     }
 
-    public void setDksCorrelationId(String dksCorrelationId) {
-        this.dksCorrelationId = dksCorrelationId;
+    public void setcorrelationId(String correlationId) {
+        this.correlationId = correlationId;
     }
 
-    public DecryptDataKeyResponse withDksCorrelationId(String dksCorrelationId) {
-        this.dksCorrelationId = dksCorrelationId;
+    public DecryptDataKeyResponse withcorrelationId(String correlationId) {
+        this.correlationId = correlationId;
         return this;
     }
 

--- a/src/main/java/uk/gov/dwp/dataworks/dto/DecryptDataKeyResponse.java
+++ b/src/main/java/uk/gov/dwp/dataworks/dto/DecryptDataKeyResponse.java
@@ -13,9 +13,25 @@ public class DecryptDataKeyResponse {
     @ApiModelProperty(notes="The decrypted data key")
     public final String plaintextDataKey;
 
+    @ApiModelProperty(notes="DKS Correlation Id passed in from the client call")
+    public String dksCorrelationId = "NOT_SET";
+
     public DecryptDataKeyResponse(String dataKeyDecryptionKeyId, String plaintextDataKey) {
         this.dataKeyDecryptionKeyId = dataKeyDecryptionKeyId;
         this.plaintextDataKey = plaintextDataKey;
+    }
+
+    public String getDksCorrelationId() {
+        return dksCorrelationId;
+    }
+
+    public void setDksCorrelationId(String dksCorrelationId) {
+        this.dksCorrelationId = dksCorrelationId;
+    }
+
+    public DecryptDataKeyResponse withDksCorrelationId(String dksCorrelationId) {
+        this.dksCorrelationId = dksCorrelationId;
+        return this;
     }
 
     @Override

--- a/src/main/java/uk/gov/dwp/dataworks/dto/GenerateDataKeyResponse.java
+++ b/src/main/java/uk/gov/dwp/dataworks/dto/GenerateDataKeyResponse.java
@@ -24,15 +24,15 @@ public class GenerateDataKeyResponse {
         this.ciphertextDataKey = ciphertextDataKey;
     }
 
-    public String getcorrelationId() {
+    public String getCorrelationId() {
         return correlationId;
     }
 
-    public void setcorrelationId(String correlationId) {
+    public void setCorrelationId(String correlationId) {
         this.correlationId = correlationId;
     }
 
-    public GenerateDataKeyResponse withcorrelationId(String correlationId) {
+    public GenerateDataKeyResponse withCorrelationId(String correlationId) {
         this.correlationId = correlationId;
         return this;
     }

--- a/src/main/java/uk/gov/dwp/dataworks/dto/GenerateDataKeyResponse.java
+++ b/src/main/java/uk/gov/dwp/dataworks/dto/GenerateDataKeyResponse.java
@@ -6,14 +6,17 @@ import java.util.Objects;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
 public class GenerateDataKeyResponse {
-    @ApiModelProperty(notes="The id of the encryption key that was used to encrypt the data key into ciphertext")
+    @ApiModelProperty(notes = "The id of the encryption key that was used to encrypt the data key into ciphertext")
     public final String dataKeyEncryptionKeyId;
 
-    @ApiModelProperty(notes="The data key in plaintext")
+    @ApiModelProperty(notes = "The data key in plaintext")
     public final String plaintextDataKey;
 
-    @ApiModelProperty(notes="The data key in ciphertext, encrypted by the data key encryption key")
+    @ApiModelProperty(notes = "The data key in ciphertext, encrypted by the data key encryption key")
     public final String ciphertextDataKey;
+
+    @ApiModelProperty(notes = "DKS Correlation Id passed in from the client call")
+    public String dksCorrelationId = "NOT_SET";
 
     public GenerateDataKeyResponse(String dataKeyEncryptionKeyId, String plaintextDataKey, String ciphertextDataKey) {
         this.dataKeyEncryptionKeyId = dataKeyEncryptionKeyId;
@@ -21,25 +24,41 @@ public class GenerateDataKeyResponse {
         this.ciphertextDataKey = ciphertextDataKey;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-        GenerateDataKeyResponse that = (GenerateDataKeyResponse) o;
-        return Objects.equals(dataKeyEncryptionKeyId, that.dataKeyEncryptionKeyId) && Objects
-                .equals(plaintextDataKey, that.plaintextDataKey) && Objects
-                .equals(ciphertextDataKey, that.ciphertextDataKey);
+    public String getDksCorrelationId() {
+        return dksCorrelationId;
     }
 
-    @Override public int hashCode() {
+    public void setDksCorrelationId(String dksCorrelationId) {
+        this.dksCorrelationId = dksCorrelationId;
+    }
+
+    public GenerateDataKeyResponse withDksCorrelationId(String dksCorrelationId) {
+        this.dksCorrelationId = dksCorrelationId;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GenerateDataKeyResponse that = (GenerateDataKeyResponse) o;
+        return Objects.equals(dataKeyEncryptionKeyId, that.dataKeyEncryptionKeyId)
+                && Objects.equals(plaintextDataKey, that.plaintextDataKey)
+                && Objects.equals(ciphertextDataKey, that.ciphertextDataKey);
+    }
+
+    @Override
+    public int hashCode() {
         return Objects.hash(dataKeyEncryptionKeyId, plaintextDataKey, ciphertextDataKey);
     }
 
-    @Override public String toString() {
+    @Override
+    public String toString() {
         return "GenerateDataKeyResponse{" + "dataKeyEncryptionKeyId='" + dataKeyEncryptionKeyId + '\''
-                + ", plaintextDataKey='" + plaintextDataKey + '\'' + ", ciphertextDataKey='" + ciphertextDataKey + '\''
-                + '}';
+                + ", plaintextDataKey='" + plaintextDataKey + '\'' + ", ciphertextDataKey='" + ciphertextDataKey + '\'' + '}';
     }
 }

--- a/src/main/java/uk/gov/dwp/dataworks/dto/GenerateDataKeyResponse.java
+++ b/src/main/java/uk/gov/dwp/dataworks/dto/GenerateDataKeyResponse.java
@@ -16,7 +16,7 @@ public class GenerateDataKeyResponse {
     public final String ciphertextDataKey;
 
     @ApiModelProperty(notes = "DKS Correlation Id passed in from the client call")
-    public String dksCorrelationId = "NOT_SET";
+    public String correlationId = "NOT_SET";
 
     public GenerateDataKeyResponse(String dataKeyEncryptionKeyId, String plaintextDataKey, String ciphertextDataKey) {
         this.dataKeyEncryptionKeyId = dataKeyEncryptionKeyId;
@@ -24,16 +24,16 @@ public class GenerateDataKeyResponse {
         this.ciphertextDataKey = ciphertextDataKey;
     }
 
-    public String getDksCorrelationId() {
-        return dksCorrelationId;
+    public String getcorrelationId() {
+        return correlationId;
     }
 
-    public void setDksCorrelationId(String dksCorrelationId) {
-        this.dksCorrelationId = dksCorrelationId;
+    public void setcorrelationId(String correlationId) {
+        this.correlationId = correlationId;
     }
 
-    public GenerateDataKeyResponse withDksCorrelationId(String dksCorrelationId) {
-        this.dksCorrelationId = dksCorrelationId;
+    public GenerateDataKeyResponse withcorrelationId(String correlationId) {
+        this.correlationId = correlationId;
         return this;
     }
 

--- a/src/main/java/uk/gov/dwp/dataworks/dto/HealthCheckResponse.java
+++ b/src/main/java/uk/gov/dwp/dataworks/dto/HealthCheckResponse.java
@@ -10,20 +10,23 @@ public class HealthCheckResponse {
 
     public enum Health {OK, BAD}
 
-    @ApiModelProperty(notes="Can the controller see its dependencies.")
+    @ApiModelProperty(notes = "Can the controller see its dependencies.")
     private Health encryptionService;
 
-    @ApiModelProperty(notes="Can the controller fetch the current master key.")
+    @ApiModelProperty(notes = "Can the controller fetch the current master key.")
     private Health masterKey;
 
-    @ApiModelProperty(notes="Can the controller generate a new data key.")
+    @ApiModelProperty(notes = "Can the controller generate a new data key.")
     private Health dataKeyGenerator;
 
-    @ApiModelProperty(notes="Can the controller encrypt a new data key.")
+    @ApiModelProperty(notes = "Can the controller encrypt a new data key.")
     private Health encryption;
 
-    @ApiModelProperty(notes="Can the controller decrypt an encrypted data key.")
+    @ApiModelProperty(notes = "Can the controller decrypt an encrypted data key.")
     private Health decryption;
+
+    @ApiModelProperty(notes = "DKS Correlation Id passed in from the client call")
+    private String dksCorrelationId = "NOT_SET";
 
     private Map<String, String> trustedCertificates;
 
@@ -37,8 +40,10 @@ public class HealthCheckResponse {
     }
 
     public HealthCheckResponse(Health encryptionService,
-            Health masterKey, Health dataKeyGenerator, Health encryption,
-            Health decryption) {
+                               Health masterKey,
+                               Health dataKeyGenerator,
+                               Health encryption,
+                               Health decryption) {
         this.encryptionService = encryptionService;
         this.masterKey = masterKey;
         this.dataKeyGenerator = dataKeyGenerator;
@@ -102,4 +107,18 @@ public class HealthCheckResponse {
     public void setTrustedCertificates(Map<String, String> trustedCertificates) {
         this.trustedCertificates = trustedCertificates;
     }
+
+    public String getDksCorrelationId() {
+        return dksCorrelationId;
+    }
+
+    public void setDksCorrelationId(String dksCorrelationId) {
+        this.dksCorrelationId = dksCorrelationId;
+    }
+
+    public HealthCheckResponse withDksCorrelationId(String dksCorrelationId) {
+        this.dksCorrelationId = dksCorrelationId;
+        return this;
+    }
+
 }

--- a/src/main/java/uk/gov/dwp/dataworks/dto/HealthCheckResponse.java
+++ b/src/main/java/uk/gov/dwp/dataworks/dto/HealthCheckResponse.java
@@ -108,15 +108,15 @@ public class HealthCheckResponse {
         this.trustedCertificates = trustedCertificates;
     }
 
-    public String getcorrelationId() {
+    public String getCorrelationId() {
         return correlationId;
     }
 
-    public void setcorrelationId(String correlationId) {
+    public void setCorrelationId(String correlationId) {
         this.correlationId = correlationId;
     }
 
-    public HealthCheckResponse withcorrelationId(String correlationId) {
+    public HealthCheckResponse withCorrelationId(String correlationId) {
         this.correlationId = correlationId;
         return this;
     }

--- a/src/main/java/uk/gov/dwp/dataworks/dto/HealthCheckResponse.java
+++ b/src/main/java/uk/gov/dwp/dataworks/dto/HealthCheckResponse.java
@@ -26,7 +26,7 @@ public class HealthCheckResponse {
     private Health decryption;
 
     @ApiModelProperty(notes = "DKS Correlation Id passed in from the client call")
-    private String dksCorrelationId = "NOT_SET";
+    private String correlationId = "NOT_SET";
 
     private Map<String, String> trustedCertificates;
 
@@ -108,16 +108,16 @@ public class HealthCheckResponse {
         this.trustedCertificates = trustedCertificates;
     }
 
-    public String getDksCorrelationId() {
-        return dksCorrelationId;
+    public String getcorrelationId() {
+        return correlationId;
     }
 
-    public void setDksCorrelationId(String dksCorrelationId) {
-        this.dksCorrelationId = dksCorrelationId;
+    public void setcorrelationId(String correlationId) {
+        this.correlationId = correlationId;
     }
 
-    public HealthCheckResponse withDksCorrelationId(String dksCorrelationId) {
-        this.dksCorrelationId = dksCorrelationId;
+    public HealthCheckResponse withcorrelationId(String correlationId) {
+        this.correlationId = correlationId;
         return this;
     }
 

--- a/src/main/java/uk/gov/dwp/dataworks/errors/CurrentKeyIdException.java
+++ b/src/main/java/uk/gov/dwp/dataworks/errors/CurrentKeyIdException.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
 public class CurrentKeyIdException extends RuntimeException {
 
-    public CurrentKeyIdException() {
-        super("Failed to retrieve the current key id.");
+    public CurrentKeyIdException(String correlationId) {
+        super("Failed to retrieve the current key id. correlation_id: " + correlationId);
     }
 }

--- a/src/main/java/uk/gov/dwp/dataworks/errors/CurrentKeyIdException.java
+++ b/src/main/java/uk/gov/dwp/dataworks/errors/CurrentKeyIdException.java
@@ -4,7 +4,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
-public class CurrentKeyIdException extends RuntimeException  {
+public class CurrentKeyIdException extends RuntimeException {
 
     public CurrentKeyIdException() {
         super("Failed to retrieve the current key id.");

--- a/src/main/java/uk/gov/dwp/dataworks/errors/DataKeyDecryptionException.java
+++ b/src/main/java/uk/gov/dwp/dataworks/errors/DataKeyDecryptionException.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
 public class DataKeyDecryptionException extends RuntimeException {
 
-    public DataKeyDecryptionException() {
-        super("Failed to decrypt this data key due to an internal error. Try again later.");
+    public DataKeyDecryptionException(String correlationId) {
+        super("Failed to decrypt this data key due to an internal error. Try again later. correlation_id: " + correlationId);
     }
 }

--- a/src/main/java/uk/gov/dwp/dataworks/errors/DataKeyGenerationException.java
+++ b/src/main/java/uk/gov/dwp/dataworks/errors/DataKeyGenerationException.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
 public class DataKeyGenerationException extends RuntimeException {
 
-    public DataKeyGenerationException() {
-        super("Failed to generate a new data key due to an internal error. Try again later.");
+    public DataKeyGenerationException(String correlationId) {
+        super("Failed to generate a new data key due to an internal error. Try again later. correlation_id: " + correlationId);
     }
 }

--- a/src/main/java/uk/gov/dwp/dataworks/errors/GarbledDataKeyException.java
+++ b/src/main/java/uk/gov/dwp/dataworks/errors/GarbledDataKeyException.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 @ResponseStatus(HttpStatus.BAD_REQUEST)
 public class GarbledDataKeyException extends RuntimeException {
 
-    public GarbledDataKeyException() {
-        super("The supplied data key could not be decrypted. Either the ciphertext is invalid or the data key encryption key is incorrect.");
+    public GarbledDataKeyException(String correlationId) {
+        super("The supplied data key could not be decrypted. Either the ciphertext is invalid or the data key encryption key is incorrect. correlation_id: " + correlationId);
     }
 }

--- a/src/main/java/uk/gov/dwp/dataworks/errors/UnusableParameterException.java
+++ b/src/main/java/uk/gov/dwp/dataworks/errors/UnusableParameterException.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 @ResponseStatus(HttpStatus.BAD_REQUEST)
 public class UnusableParameterException extends RuntimeException {
 
-    public UnusableParameterException() {
-        super("The supplied key or cyphertext are unusable.");
+    public UnusableParameterException(String correlationId) {
+        super("The supplied key or cyphertext are unusable. correlation_id: " + correlationId);
     }
 }

--- a/src/main/java/uk/gov/dwp/dataworks/provider/CurrentKeyIdProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/CurrentKeyIdProvider.java
@@ -3,5 +3,5 @@ package uk.gov.dwp.dataworks.provider;
 import uk.gov.dwp.dataworks.errors.CurrentKeyIdException;
 
 public interface CurrentKeyIdProvider extends Dependent {
-    String getKeyId(String dksCorrelationId) throws CurrentKeyIdException;
+    String getKeyId(String correlationId) throws CurrentKeyIdException;
 }

--- a/src/main/java/uk/gov/dwp/dataworks/provider/CurrentKeyIdProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/CurrentKeyIdProvider.java
@@ -3,5 +3,5 @@ package uk.gov.dwp.dataworks.provider;
 import uk.gov.dwp.dataworks.errors.CurrentKeyIdException;
 
 public interface CurrentKeyIdProvider extends Dependent {
-    String getKeyId() throws CurrentKeyIdException;
+    String getKeyId(String dksCorrelationId) throws CurrentKeyIdException;
 }

--- a/src/main/java/uk/gov/dwp/dataworks/provider/DataKeyDecryptionProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/DataKeyDecryptionProvider.java
@@ -5,5 +5,6 @@ import uk.gov.dwp.dataworks.errors.MasterKeystoreException;
 
 public interface DataKeyDecryptionProvider extends Dependent {
     int MAX_PAYLOAD_SIZE = 32000;
+
     DecryptDataKeyResponse decryptDataKey(String keyId, String ciphertextDataKey) throws MasterKeystoreException;
 }

--- a/src/main/java/uk/gov/dwp/dataworks/provider/DataKeyDecryptionProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/DataKeyDecryptionProvider.java
@@ -6,5 +6,5 @@ import uk.gov.dwp.dataworks.errors.MasterKeystoreException;
 public interface DataKeyDecryptionProvider extends Dependent {
     int MAX_PAYLOAD_SIZE = 32000;
 
-    DecryptDataKeyResponse decryptDataKey(String keyId, String ciphertextDataKey, String dksCorrelationId) throws MasterKeystoreException;
+    DecryptDataKeyResponse decryptDataKey(String keyId, String ciphertextDataKey, String correlationId) throws MasterKeystoreException;
 }

--- a/src/main/java/uk/gov/dwp/dataworks/provider/DataKeyDecryptionProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/DataKeyDecryptionProvider.java
@@ -6,5 +6,5 @@ import uk.gov.dwp.dataworks.errors.MasterKeystoreException;
 public interface DataKeyDecryptionProvider extends Dependent {
     int MAX_PAYLOAD_SIZE = 32000;
 
-    DecryptDataKeyResponse decryptDataKey(String keyId, String ciphertextDataKey) throws MasterKeystoreException;
+    DecryptDataKeyResponse decryptDataKey(String keyId, String ciphertextDataKey, String dksCorrelationId) throws MasterKeystoreException;
 }

--- a/src/main/java/uk/gov/dwp/dataworks/provider/DataKeyGeneratorProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/DataKeyGeneratorProvider.java
@@ -6,7 +6,7 @@ import uk.gov.dwp.dataworks.errors.MasterKeystoreException;
 
 public interface DataKeyGeneratorProvider extends Dependent {
 
-    GenerateDataKeyResponse generateDataKey(String encryptionKeyId, String dksCorrelationId)
+    GenerateDataKeyResponse generateDataKey(String encryptionKeyId, String correlationId)
             throws DataKeyGenerationException, MasterKeystoreException;
 
     @Override

--- a/src/main/java/uk/gov/dwp/dataworks/provider/DataKeyGeneratorProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/DataKeyGeneratorProvider.java
@@ -5,7 +5,10 @@ import uk.gov.dwp.dataworks.errors.DataKeyGenerationException;
 import uk.gov.dwp.dataworks.errors.MasterKeystoreException;
 
 public interface DataKeyGeneratorProvider extends Dependent {
+
     GenerateDataKeyResponse generateDataKey(String encryptionKeyId)
             throws DataKeyGenerationException, MasterKeystoreException;
+
+    @Override
     boolean canSeeDependencies();
 }

--- a/src/main/java/uk/gov/dwp/dataworks/provider/DataKeyGeneratorProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/DataKeyGeneratorProvider.java
@@ -6,7 +6,7 @@ import uk.gov.dwp.dataworks.errors.MasterKeystoreException;
 
 public interface DataKeyGeneratorProvider extends Dependent {
 
-    GenerateDataKeyResponse generateDataKey(String encryptionKeyId)
+    GenerateDataKeyResponse generateDataKey(String encryptionKeyId, String dksCorrelationId)
             throws DataKeyGenerationException, MasterKeystoreException;
 
     @Override

--- a/src/main/java/uk/gov/dwp/dataworks/provider/aws/AwsCurrentKeyIdProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/aws/AwsCurrentKeyIdProvider.java
@@ -24,7 +24,7 @@ public class AwsCurrentKeyIdProvider implements CurrentKeyIdProvider {
         this.awsSimpleSystemsManagementClient = awsSimpleSystemsManagementClient;
     }
 
-    public String getKeyId(String dksCorrelationId) throws CurrentKeyIdException {
+    public String getKeyId(String correlationId) throws CurrentKeyIdException {
         try {
             GetParameterRequest request = new GetParameterRequest()
                     .withName(masterkeyParameterName)
@@ -32,8 +32,9 @@ public class AwsCurrentKeyIdProvider implements CurrentKeyIdProvider {
             GetParameterResult result = awsSimpleSystemsManagementClient.getParameter(request);
             return result.getParameter().getValue();
         } catch (RuntimeException e) {
-            LOGGER.error("Failed to retrieve the current key id.", e);
-            throw new CurrentKeyIdException();
+            CurrentKeyIdException wrapper = new CurrentKeyIdException(correlationId);
+            LOGGER.error(wrapper.getMessage(), e);
+            throw wrapper;
         }
     }
 

--- a/src/main/java/uk/gov/dwp/dataworks/provider/aws/AwsCurrentKeyIdProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/aws/AwsCurrentKeyIdProvider.java
@@ -24,15 +24,14 @@ public class AwsCurrentKeyIdProvider implements CurrentKeyIdProvider {
         this.awsSimpleSystemsManagementClient = awsSimpleSystemsManagementClient;
     }
 
-    public String getKeyId() throws CurrentKeyIdException {
+    public String getKeyId(String dksCorrelationId) throws CurrentKeyIdException {
         try {
             GetParameterRequest request = new GetParameterRequest()
                     .withName(masterkeyParameterName)
                     .withWithDecryption(false);
             GetParameterResult result = awsSimpleSystemsManagementClient.getParameter(request);
             return result.getParameter().getValue();
-        }
-        catch (RuntimeException e) {
+        } catch (RuntimeException e) {
             LOGGER.error("Failed to retrieve the current key id.", e);
             throw new CurrentKeyIdException();
         }
@@ -40,7 +39,7 @@ public class AwsCurrentKeyIdProvider implements CurrentKeyIdProvider {
 
     @Override
     public boolean canSeeDependencies() {
-        return getKeyId() != null;
+        return getKeyId("NOT_SET") != null;
     }
 
     @Value("${master.key.parameter.name:data_key_service.currentKeyId}")

--- a/src/main/java/uk/gov/dwp/dataworks/provider/hsm/AlternatingCaviumCryptoImplementationSupplier.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/hsm/AlternatingCaviumCryptoImplementationSupplier.java
@@ -35,8 +35,7 @@ public class AlternatingCaviumCryptoImplementationSupplier implements CryptoImpl
     static {
         try {
             Security.addProvider(new CaviumProvider());
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             throw new RuntimeException("Cavium provider not available: '" + e.getMessage() + "'", e);
         }
     }
@@ -49,8 +48,7 @@ public class AlternatingCaviumCryptoImplementationSupplier implements CryptoImpl
                     new CaviumAESKeyGenParameterSpec(128, DATA_KEY_LABEL, EXTRACTABLE, NOT_PERSISTENT);
             keyGenerator.init(aesSpec);
             return keyGenerator.generateKey();
-        }
-        catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidAlgorithmParameterException e) {
+        } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidAlgorithmParameterException e) {
             LOGGER.error("Failed to create data key", e);
             throw new CryptoImplementationSupplierException(e);
         }
@@ -64,12 +62,10 @@ public class AlternatingCaviumCryptoImplementationSupplier implements CryptoImpl
             LOGGER.info("Public key bytes: '{}'.", new String(Base64.getEncoder().encode(publicKey.getEncoded())));
             Cipher cipher = bouncyCastleCompatibleCipher(Cipher.ENCRYPT_MODE, publicKey);
             return Base64.getEncoder().encode(cipher.doFinal(dataKey.getEncoded()));
-        }
-        catch (BadPaddingException| NoSuchAlgorithmException | NoSuchProviderException |
+        } catch (BadPaddingException | NoSuchAlgorithmException | NoSuchProviderException |
                 NoSuchPaddingException | InvalidKeyException | IllegalBlockSizeException | InvalidAlgorithmParameterException e) {
             throw new CryptoImplementationSupplierException(e);
-        }
-        catch (CFM2Exception e) {
+        } catch (CFM2Exception e) {
             String message = "Failed to encrypt key, retry will be attempted unless max attempts reached";
             LOGGER.warn(message);
             throw new MasterKeystoreException(message, e);
@@ -87,19 +83,16 @@ public class AlternatingCaviumCryptoImplementationSupplier implements CryptoImpl
             try {
                 LOGGER.info("Trying SunJCE compatible cipher.");
                 return decryptedKey(jceCipher, ciphertextDataKey);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 try {
                     Cipher bcCipher = bouncyCastleCompatibleCipher(Cipher.DECRYPT_MODE, privateKey);
                     LOGGER.info("SunJCE failed trying bouncy castle compatible cipher.");
                     return decryptedKey(bcCipher, ciphertextDataKey);
-                }
-                catch (Exception e2) {
+                } catch (Exception e2) {
                     throw new GarbledDataKeyException();
                 }
             }
-        }
-        catch (InvalidKeyException |
+        } catch (InvalidKeyException |
                 NoSuchPaddingException |
                 NoSuchAlgorithmException |
                 NoSuchProviderException |
@@ -116,13 +109,11 @@ public class AlternatingCaviumCryptoImplementationSupplier implements CryptoImpl
             byte[] decrypted = cipher.doFinal(decodedCipher);
             if (decrypted != null) {
                 return new String(Base64.getEncoder().encode(decrypted));
-            }
-            else {
+            } else {
                 LOGGER.warn("Decrypting key '{}' yielded null.", ciphertextDataKey);
                 throw new GarbledDataKeyException();
             }
-        }
-        catch (BadPaddingException | IllegalBlockSizeException e) {
+        } catch (BadPaddingException | IllegalBlockSizeException e) {
             LOGGER.warn("Failed to decrypt key: '{}'.", e.getMessage());
             throw new GarbledDataKeyException();
         }
@@ -170,7 +161,7 @@ public class AlternatingCaviumCryptoImplementationSupplier implements CryptoImpl
     private CaviumRSAPublicKey publicKey(Integer wrappingKeyHandle) throws CFM2Exception {
         LOGGER.info("publicKeyHandle: '{}'.", wrappingKeyHandle);
         byte[] keyAttribute = Util.getKeyAttributes(wrappingKeyHandle);
-        return new CaviumRSAPublicKey(wrappingKeyHandle,  new CaviumKeyAttributes(keyAttribute));
+        return new CaviumRSAPublicKey(wrappingKeyHandle, new CaviumKeyAttributes(keyAttribute));
     }
 
     @Override
@@ -178,8 +169,7 @@ public class AlternatingCaviumCryptoImplementationSupplier implements CryptoImpl
         try {
             LOGGER.debug("Deleting session key.");
             Util.deleteKey((CaviumKey) datakey);
-        }
-        catch (CFM2Exception e) {
+        } catch (CFM2Exception e) {
             LOGGER.error("Failed to delete datakey: '" + e.getMessage() + "'", e);
         }
 

--- a/src/main/java/uk/gov/dwp/dataworks/provider/hsm/AlternatingCaviumCryptoImplementationSupplier.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/hsm/AlternatingCaviumCryptoImplementationSupplier.java
@@ -49,7 +49,7 @@ public class AlternatingCaviumCryptoImplementationSupplier implements CryptoImpl
             keyGenerator.init(aesSpec);
             return keyGenerator.generateKey();
         } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidAlgorithmParameterException e) {
-            LOGGER.error("Failed to create data key", e);
+            LOGGER.error("Failed to create data key. correlation_id: " + correlationId, e);
             throw new CryptoImplementationSupplierException(e);
         }
     }
@@ -59,7 +59,8 @@ public class AlternatingCaviumCryptoImplementationSupplier implements CryptoImpl
             throws CryptoImplementationSupplierException, MasterKeystoreException {
         try {
             CaviumRSAPublicKey publicKey = publicKey(wrappingKeyHandle);
-            LOGGER.info("Public key bytes: '{}'.", new String(Base64.getEncoder().encode(publicKey.getEncoded())));
+            String key = new String(Base64.getEncoder().encode(publicKey.getEncoded()));
+            LOGGER.info("Public key bytes: '{}'. correlation_id: {}", key, correlationId);
             Cipher cipher = bouncyCastleCompatibleCipher(Cipher.ENCRYPT_MODE, publicKey);
             return Base64.getEncoder().encode(cipher.doFinal(dataKey.getEncoded()));
         } catch (BadPaddingException | NoSuchAlgorithmException | NoSuchProviderException |

--- a/src/main/java/uk/gov/dwp/dataworks/provider/hsm/CryptoImplementationSupplier.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/hsm/CryptoImplementationSupplier.java
@@ -7,8 +7,10 @@ import java.security.Key;
 
 public interface CryptoImplementationSupplier {
     Key dataKey() throws CryptoImplementationSupplierException;
+
     byte[] encryptedKey(Integer wrappingKeyHandle, Key dataKey)
             throws CryptoImplementationSupplierException, MasterKeystoreException;
+
     String decryptedKey(Integer decryptionKeyHandle, String ciphertextDataKey)
             throws CryptoImplementationSupplierException, MasterKeystoreException;
 

--- a/src/main/java/uk/gov/dwp/dataworks/provider/hsm/CryptoImplementationSupplier.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/hsm/CryptoImplementationSupplier.java
@@ -6,12 +6,12 @@ import uk.gov.dwp.dataworks.errors.MasterKeystoreException;
 import java.security.Key;
 
 public interface CryptoImplementationSupplier {
-    Key dataKey() throws CryptoImplementationSupplierException;
+    Key dataKey(String correlationId) throws CryptoImplementationSupplierException;
 
-    byte[] encryptedKey(Integer wrappingKeyHandle, Key dataKey)
+    byte[] encryptedKey(Integer wrappingKeyHandle, Key dataKey, String correlationId)
             throws CryptoImplementationSupplierException, MasterKeystoreException;
 
-    String decryptedKey(Integer decryptionKeyHandle, String ciphertextDataKey)
+    String decryptedKey(Integer decryptionKeyHandle, String ciphertextDataKey, String correlationId)
             throws CryptoImplementationSupplierException, MasterKeystoreException;
 
     void cleanupKey(Key datakey);

--- a/src/main/java/uk/gov/dwp/dataworks/provider/hsm/EncryptingCaviumCryptoImplementationSupplier.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/hsm/EncryptingCaviumCryptoImplementationSupplier.java
@@ -31,8 +31,7 @@ public class EncryptingCaviumCryptoImplementationSupplier implements CryptoImple
     static {
         try {
             Security.addProvider(new CaviumProvider());
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             throw new RuntimeException("Cavium provider not available: '" + e.getMessage() + "'", e);
         }
     }
@@ -45,8 +44,7 @@ public class EncryptingCaviumCryptoImplementationSupplier implements CryptoImple
                     new CaviumAESKeyGenParameterSpec(128, DATA_KEY_LABEL, EXTRACTABLE, NOT_PERSISTENT);
             keyGenerator.init(aesSpec);
             return keyGenerator.generateKey();
-        }
-        catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidAlgorithmParameterException e) {
+        } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidAlgorithmParameterException e) {
             LOGGER.error("Failed to create data key", e);
             throw new CryptoImplementationSupplierException(e);
         }
@@ -58,17 +56,15 @@ public class EncryptingCaviumCryptoImplementationSupplier implements CryptoImple
         try {
             LOGGER.info("wrappingKeyHandle: '{}'.", wrappingKeyHandle);
             byte[] keyAttribute = Util.getKeyAttributes(wrappingKeyHandle);
-            CaviumRSAPublicKey publicKey = new CaviumRSAPublicKey(wrappingKeyHandle,  new CaviumKeyAttributes(keyAttribute));
+            CaviumRSAPublicKey publicKey = new CaviumRSAPublicKey(wrappingKeyHandle, new CaviumKeyAttributes(keyAttribute));
             LOGGER.info("Public key bytes: '{}'.", new String(Base64.getEncoder().encode(publicKey.getEncoded())));
             Cipher cipher = Cipher.getInstance(cipherTransformation, CAVIUM_PROVIDER);
             cipher.init(Cipher.ENCRYPT_MODE, publicKey);
             return Base64.getEncoder().encode(cipher.doFinal(dataKey.getEncoded()));
-        }
-        catch (BadPaddingException| NoSuchAlgorithmException | NoSuchProviderException |
-                NoSuchPaddingException | InvalidKeyException | IllegalBlockSizeException  e) {
+        } catch (BadPaddingException | NoSuchAlgorithmException | NoSuchProviderException |
+                NoSuchPaddingException | InvalidKeyException | IllegalBlockSizeException e) {
             throw new CryptoImplementationSupplierException(e);
-        }
-        catch (CFM2Exception e) {
+        } catch (CFM2Exception e) {
             String message = "Failed to encrypt key, retry will be attempted unless max attempts reached";
             LOGGER.warn(message);
             throw new MasterKeystoreException(message, e);
@@ -89,18 +85,14 @@ public class EncryptingCaviumCryptoImplementationSupplier implements CryptoImple
             byte[] decrypted = cipher.doFinal(decodedCipher);
             if (decrypted != null) {
                 return new String(Base64.getEncoder().encode(decrypted));
-            }
-            else {
+            } else {
                 throw new GarbledDataKeyException();
             }
-        }
-        catch (NoSuchPaddingException | NoSuchAlgorithmException | NoSuchProviderException  | IllegalBlockSizeException | BadPaddingException e) {
+        } catch (NoSuchPaddingException | NoSuchAlgorithmException | NoSuchProviderException | IllegalBlockSizeException | BadPaddingException e) {
             throw new CryptoImplementationSupplierException(e);
-        }
-        catch (InvalidKeyException e) {
+        } catch (InvalidKeyException e) {
             throw new GarbledDataKeyException();
-        }
-        catch (CFM2Exception e) {
+        } catch (CFM2Exception e) {
             String message = "Failed to decrypt key, retry will be attempted unless max attempts reached";
             LOGGER.warn("Failed to decrypt key: '{}', '{}', '{}'", e.getMessage(), e.getStatus(), e.getClass().getSimpleName());
             LOGGER.warn(message);
@@ -113,8 +105,7 @@ public class EncryptingCaviumCryptoImplementationSupplier implements CryptoImple
         try {
             LOGGER.debug("Deleting session key.");
             Util.deleteKey((CaviumKey) datakey);
-        }
-        catch (CFM2Exception e) {
+        } catch (CFM2Exception e) {
             LOGGER.error("Failed to delete datakey: '" + e.getMessage() + "'", e);
         }
 

--- a/src/main/java/uk/gov/dwp/dataworks/provider/hsm/HsmDataKeyDecryptionProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/hsm/HsmDataKeyDecryptionProvider.java
@@ -33,7 +33,7 @@ public class HsmDataKeyDecryptionProvider extends HsmDependent
             value = {MasterKeystoreException.class},
             maxAttempts = MAX_ATTEMPTS,
             backoff = @Backoff(delay = INITIAL_BACKOFF_MILLIS, multiplier = BACKOFF_MULTIPLIER))
-    public DecryptDataKeyResponse decryptDataKey(String decryptionKeyId, String ciphertextDataKey)
+    public DecryptDataKeyResponse decryptDataKey(String decryptionKeyId, String ciphertextDataKey, String dksCorrelationId)
             throws MasterKeystoreException {
         try {
             loginManager.login();

--- a/src/main/java/uk/gov/dwp/dataworks/provider/hsm/HsmDataKeyDecryptionProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/hsm/HsmDataKeyDecryptionProvider.java
@@ -21,16 +21,16 @@ public class HsmDataKeyDecryptionProvider extends HsmDependent
     private final int MAX_ATTEMPTS = 10;
 
     HsmDataKeyDecryptionProvider(CurrentKeyIdProvider currentKeyIdProvider,
-            DataKeyGeneratorProvider dataKeyGeneratorProvider,
-            HsmLoginManager loginManager,
-            CryptoImplementationSupplier cryptoImplementationSupplier) {
+                                 DataKeyGeneratorProvider dataKeyGeneratorProvider,
+                                 HsmLoginManager loginManager,
+                                 CryptoImplementationSupplier cryptoImplementationSupplier) {
         super(loginManager);
         this.cryptoImplementationSupplier = cryptoImplementationSupplier;
     }
 
     @Override
     @Retryable(
-            value = { MasterKeystoreException.class },
+            value = {MasterKeystoreException.class},
             maxAttempts = MAX_ATTEMPTS,
             backoff = @Backoff(delay = INITIAL_BACKOFF_MILLIS, multiplier = BACKOFF_MULTIPLIER))
     public DecryptDataKeyResponse decryptDataKey(String decryptionKeyId, String ciphertextDataKey)
@@ -40,12 +40,10 @@ public class HsmDataKeyDecryptionProvider extends HsmDependent
             Integer decryptionKeyHandle = privateKeyHandle(decryptionKeyId);
             String decryptedKey = cryptoImplementationSupplier.decryptedKey(decryptionKeyHandle, ciphertextDataKey);
             return new DecryptDataKeyResponse(decryptionKeyId, decryptedKey);
-        }
-        catch (CryptoImplementationSupplierException e) {
+        } catch (CryptoImplementationSupplierException e) {
             throw new DataKeyDecryptionException();
-        }
-        finally {
-                loginManager.logout();
+        } finally {
+            loginManager.logout();
         }
     }
 

--- a/src/main/java/uk/gov/dwp/dataworks/provider/hsm/HsmDataKeyDecryptionProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/hsm/HsmDataKeyDecryptionProvider.java
@@ -33,15 +33,15 @@ public class HsmDataKeyDecryptionProvider extends HsmDependent
             value = {MasterKeystoreException.class},
             maxAttempts = MAX_ATTEMPTS,
             backoff = @Backoff(delay = INITIAL_BACKOFF_MILLIS, multiplier = BACKOFF_MULTIPLIER))
-    public DecryptDataKeyResponse decryptDataKey(String decryptionKeyId, String ciphertextDataKey, String dksCorrelationId)
+    public DecryptDataKeyResponse decryptDataKey(String decryptionKeyId, String ciphertextDataKey, String correlationId)
             throws MasterKeystoreException {
         try {
             loginManager.login();
-            Integer decryptionKeyHandle = privateKeyHandle(decryptionKeyId);
-            String decryptedKey = cryptoImplementationSupplier.decryptedKey(decryptionKeyHandle, ciphertextDataKey);
+            Integer decryptionKeyHandle = privateKeyHandle(decryptionKeyId, correlationId);
+            String decryptedKey = cryptoImplementationSupplier.decryptedKey(decryptionKeyHandle, ciphertextDataKey, correlationId);
             return new DecryptDataKeyResponse(decryptionKeyId, decryptedKey);
         } catch (CryptoImplementationSupplierException e) {
-            throw new DataKeyDecryptionException();
+            throw new DataKeyDecryptionException(correlationId);
         } finally {
             loginManager.logout();
         }

--- a/src/main/java/uk/gov/dwp/dataworks/provider/hsm/HsmDataKeyGeneratorProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/hsm/HsmDataKeyGeneratorProvider.java
@@ -1,8 +1,5 @@
 package uk.gov.dwp.dataworks.provider.hsm;
 
-import com.cavium.cfm2.CFM2Exception;
-import com.cavium.cfm2.Util;
-import com.cavium.key.CaviumKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;

--- a/src/main/java/uk/gov/dwp/dataworks/provider/hsm/HsmDataKeyGeneratorProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/hsm/HsmDataKeyGeneratorProvider.java
@@ -26,14 +26,14 @@ public class HsmDataKeyGeneratorProvider extends HsmDependent implements DataKey
     private final static Logger LOGGER = LoggerFactory.getLogger(HsmDataKeyGeneratorProvider.class);
 
     public HsmDataKeyGeneratorProvider(HsmLoginManager loginManager,
-            CryptoImplementationSupplier cryptoImplementationSupplier) {
+                                       CryptoImplementationSupplier cryptoImplementationSupplier) {
         super(loginManager);
         this.cryptoImplementationSupplier = cryptoImplementationSupplier;
     }
 
     @Override
     @Retryable(
-            value = { MasterKeystoreException.class },
+            value = {MasterKeystoreException.class},
             maxAttempts = MAX_ATTEMPTS,
             backoff = @Backoff(delay = INITIAL_BACKOFF_MILLIS, multiplier = BACKOFF_MULTIPLIER))
     public GenerateDataKeyResponse generateDataKey(String keyId)
@@ -46,14 +46,12 @@ public class HsmDataKeyGeneratorProvider extends HsmDependent implements DataKey
             byte[] ciphertext = cryptoImplementationSupplier.encryptedKey(publicKeyHandle, dataKey);
             cryptoImplementationSupplier.cleanupKey(dataKey);
             return new GenerateDataKeyResponse(keyId,
-                                                new String(plaintextDatakey),
-                                                new String(ciphertext));
-        }
-        catch (CryptoImplementationSupplierException e) {
+                    new String(plaintextDatakey),
+                    new String(ciphertext));
+        } catch (CryptoImplementationSupplierException e) {
             LOGGER.error("Failure encountered trying to generate a new datakey due to an internal error. Try again later.", e);
             throw new DataKeyGenerationException();
-        }
-        finally {
+        } finally {
             loginManager.logout();
         }
     }
@@ -62,5 +60,6 @@ public class HsmDataKeyGeneratorProvider extends HsmDependent implements DataKey
     public boolean canSeeDependencies() {
         return this.cryptoImplementationSupplier != null;
     }
+
     private final CryptoImplementationSupplier cryptoImplementationSupplier;
 }

--- a/src/main/java/uk/gov/dwp/dataworks/provider/hsm/HsmDataKeyGeneratorProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/hsm/HsmDataKeyGeneratorProvider.java
@@ -33,7 +33,7 @@ public class HsmDataKeyGeneratorProvider extends HsmDependent implements DataKey
             value = {MasterKeystoreException.class},
             maxAttempts = MAX_ATTEMPTS,
             backoff = @Backoff(delay = INITIAL_BACKOFF_MILLIS, multiplier = BACKOFF_MULTIPLIER))
-    public GenerateDataKeyResponse generateDataKey(String keyId)
+    public GenerateDataKeyResponse generateDataKey(String keyId, String dksCorrelationId)
             throws DataKeyGenerationException, MasterKeystoreException {
         try {
             loginManager.login();

--- a/src/main/java/uk/gov/dwp/dataworks/provider/hsm/HsmDependent.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/hsm/HsmDependent.java
@@ -24,8 +24,7 @@ public abstract class HsmDependent implements Dependent, HsmDataKeyDecryptionCon
         Matcher matcher = KEY_ID_PATTERN.matcher(keyId);
         if (matcher.matches()) {
             return Integer.parseInt(matcher.group(groupName));
-        }
-        else {
+        } else {
             throw new CurrentKeyIdException();
         }
     }

--- a/src/main/java/uk/gov/dwp/dataworks/provider/hsm/HsmDependent.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/hsm/HsmDependent.java
@@ -12,20 +12,20 @@ public abstract class HsmDependent implements Dependent, HsmDataKeyDecryptionCon
         this.loginManager = loginManager;
     }
 
-    int privateKeyHandle(String keyId) {
-        return keyHandle(keyId, PRIVATE_KEY_GROUP_NAME);
+    int privateKeyHandle(String keyId, String correlationId) {
+        return keyHandle(keyId, PRIVATE_KEY_GROUP_NAME, correlationId);
     }
 
-    int publicKeyHandle(String keyId) {
-        return keyHandle(keyId, PUBLIC_KEY_GROUP_NAME);
+    int publicKeyHandle(String keyId, String correlationId) {
+        return keyHandle(keyId, PUBLIC_KEY_GROUP_NAME, correlationId);
     }
 
-    private int keyHandle(String keyId, String groupName) {
+    private int keyHandle(String keyId, String groupName, String correlationId) {
         Matcher matcher = KEY_ID_PATTERN.matcher(keyId);
         if (matcher.matches()) {
             return Integer.parseInt(matcher.group(groupName));
         } else {
-            throw new CurrentKeyIdException();
+            throw new CurrentKeyIdException(correlationId);
         }
     }
 

--- a/src/main/java/uk/gov/dwp/dataworks/provider/hsm/ImplicitHsmLoginManager.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/hsm/ImplicitHsmLoginManager.java
@@ -14,13 +14,13 @@ public class ImplicitHsmLoginManager implements HsmLoginManager {
     private final static Logger LOGGER = LoggerFactory.getLogger(ImplicitHsmLoginManager.class);
 
     @Autowired
-    private com.cavium.cfm2.LoginManager loginManager ;
+    private com.cavium.cfm2.LoginManager loginManager;
 
     @Autowired
     private HsmCredentialsProvider hsmCredentialsProvider;
 
     @Override
-    public  void login() {
+    public void login() {
         HSMCredentials hsmCredentials = hsmCredentialsProvider.getCredentials();
         if (null != hsmCredentials) {
             LOGGER.info("Setting implicit login details");
@@ -32,6 +32,6 @@ public class ImplicitHsmLoginManager implements HsmLoginManager {
 
 
     @Override
-    public  void logout() {
+    public void logout() {
     }
 }

--- a/src/main/java/uk/gov/dwp/dataworks/provider/hsm/WrappingCaviumCryptoImplementationSupplier.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/hsm/WrappingCaviumCryptoImplementationSupplier.java
@@ -63,7 +63,8 @@ public class WrappingCaviumCryptoImplementationSupplier implements CryptoImpleme
             LOGGER.info("wrappingKeyHandle: '{}'. correlation_id: {}", wrappingKeyHandle, correlationId);
             byte[] keyAttribute = Util.getKeyAttributes(wrappingKeyHandle);
             CaviumRSAPublicKey publicKey = new CaviumRSAPublicKey(wrappingKeyHandle, new CaviumKeyAttributes(keyAttribute));
-            LOGGER.info("Public key bytes: '{}'.", new String(Base64.getEncoder().encode(publicKey.getEncoded())));
+            String key = new String(Base64.getEncoder().encode(publicKey.getEncoded()));
+            LOGGER.info("Public key bytes: '{}'. correlation_id: {}", key, correlationId);
             OAEPParameterSpec spec = new OAEPParameterSpec("SHA-256", "MGF1",
                     MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
             Cipher cipher = Cipher.getInstance("RSA/ECB/OAEPWithSHA-256ANDMGF1Padding", "Cavium");
@@ -115,7 +116,7 @@ public class WrappingCaviumCryptoImplementationSupplier implements CryptoImpleme
             LOGGER.warn("Invalid key: {}. correlation_id: {}", e.getMessage(), correlationId, e);
             throw new GarbledDataKeyException(correlationId);
         } catch (CFM2Exception e) {
-            LOGGER.warn("Failed to decrypt key: '{}', '{}', '{}'", e.getMessage(), e.getStatus(), e.getClass().getSimpleName());
+            LOGGER.warn("Failed to decrypt key: '{}', '{}', '{}'. correlation_id: {}", e.getMessage(), e.getStatus(), e.getClass().getSimpleName(), correlationId);
             String message = "Failed to decrypt key, retry will be attempted unless max attempts reached. correlation_id: " + correlationId;
             LOGGER.warn(message);
             throw new MasterKeystoreException(message, e);

--- a/src/main/java/uk/gov/dwp/dataworks/provider/hsm/WrappingCaviumCryptoImplementationSupplier.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/hsm/WrappingCaviumCryptoImplementationSupplier.java
@@ -17,7 +17,10 @@ import uk.gov.dwp.dataworks.errors.CryptoImplementationSupplierException;
 import uk.gov.dwp.dataworks.errors.GarbledDataKeyException;
 import uk.gov.dwp.dataworks.errors.MasterKeystoreException;
 
-import javax.crypto.*;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.KeyGenerator;
+import javax.crypto.NoSuchPaddingException;
 import javax.crypto.spec.OAEPParameterSpec;
 import javax.crypto.spec.PSource;
 import java.io.IOException;
@@ -34,11 +37,11 @@ public class WrappingCaviumCryptoImplementationSupplier implements CryptoImpleme
     static {
         try {
             Security.addProvider(new CaviumProvider());
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             throw new RuntimeException("Cavium provider not available: '" + e.getMessage() + "'", e);
         }
     }
+
     @Override
     public Key dataKey() throws CryptoImplementationSupplierException {
         try {
@@ -47,40 +50,37 @@ public class WrappingCaviumCryptoImplementationSupplier implements CryptoImpleme
                     new CaviumAESKeyGenParameterSpec(128, DATA_KEY_LABEL, EXTRACTABLE, NOT_PERSISTENT);
             keyGenerator.init(aesSpec);
             return keyGenerator.generateKey();
-        }
-        catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidAlgorithmParameterException e) {
+        } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidAlgorithmParameterException e) {
             LOGGER.error("Failed to create data key", e);
             throw new CryptoImplementationSupplierException(e);
         }
     }
 
 
-        @Override
-        public byte[] encryptedKey(Integer wrappingKeyHandle, Key dataKey)
-                throws CryptoImplementationSupplierException, MasterKeystoreException {
-            try {
-                LOGGER.info("wrappingKeyHandle: '{}'.", wrappingKeyHandle);
-                byte[] keyAttribute = Util.getKeyAttributes(wrappingKeyHandle);
-                CaviumRSAPublicKey publicKey = new CaviumRSAPublicKey(wrappingKeyHandle,  new CaviumKeyAttributes(keyAttribute));
-                LOGGER.info("Public key bytes: '{}'.", new String(Base64.getEncoder().encode(publicKey.getEncoded())));
-                OAEPParameterSpec spec = new OAEPParameterSpec("SHA-256", "MGF1",
-                        MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
-                Cipher cipher = Cipher.getInstance("RSA/ECB/OAEPWithSHA-256ANDMGF1Padding", "Cavium");
-                cipher.init(Cipher.WRAP_MODE, publicKey, spec);
-                return Base64.getEncoder().encode(cipher.wrap(dataKey));
-            }
-            catch (NoSuchAlgorithmException | NoSuchProviderException |
-                    NoSuchPaddingException | InvalidKeyException | IllegalBlockSizeException | InvalidAlgorithmParameterException e) {
-                throw new CryptoImplementationSupplierException(e);
-            }
-            catch (CFM2Exception e) {
-                String message = "Failed to encrypt key, retry will be attempted unless max attempts reached";
-                LOGGER.warn(message);
-                throw new MasterKeystoreException(message, e);
-            }
+    @Override
+    public byte[] encryptedKey(Integer wrappingKeyHandle, Key dataKey)
+            throws CryptoImplementationSupplierException, MasterKeystoreException {
+        try {
+            LOGGER.info("wrappingKeyHandle: '{}'.", wrappingKeyHandle);
+            byte[] keyAttribute = Util.getKeyAttributes(wrappingKeyHandle);
+            CaviumRSAPublicKey publicKey = new CaviumRSAPublicKey(wrappingKeyHandle, new CaviumKeyAttributes(keyAttribute));
+            LOGGER.info("Public key bytes: '{}'.", new String(Base64.getEncoder().encode(publicKey.getEncoded())));
+            OAEPParameterSpec spec = new OAEPParameterSpec("SHA-256", "MGF1",
+                    MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
+            Cipher cipher = Cipher.getInstance("RSA/ECB/OAEPWithSHA-256ANDMGF1Padding", "Cavium");
+            cipher.init(Cipher.WRAP_MODE, publicKey, spec);
+            return Base64.getEncoder().encode(cipher.wrap(dataKey));
+        } catch (NoSuchAlgorithmException | NoSuchProviderException |
+                NoSuchPaddingException | InvalidKeyException | IllegalBlockSizeException | InvalidAlgorithmParameterException e) {
+            throw new CryptoImplementationSupplierException(e);
+        } catch (CFM2Exception e) {
+            String message = "Failed to encrypt key, retry will be attempted unless max attempts reached";
+            LOGGER.warn(message);
+            throw new MasterKeystoreException(message, e);
         }
+    }
 
-        @Override
+    @Override
     public String decryptedKey(Integer decryptionKeyHandle, String ciphertextDataKey)
             throws CryptoImplementationSupplierException, MasterKeystoreException {
         try {
@@ -102,25 +102,20 @@ public class WrappingCaviumCryptoImplementationSupplier implements CryptoImpleme
                     LOGGER.debug("Removing unwrapped session key.");
                     cleanupKey(unwrappedKey);
                     return new String(Base64.getEncoder().encode(exportedUnwrappedKey));
-                }
-                else {
+                } else {
                     LOGGER.warn("Exported unwrapped key is null, unwrappedKey: '{}'", unwrappedKey);
                     throw new GarbledDataKeyException();
                 }
-            }
-            else {
+            } else {
                 LOGGER.warn("Unwrapped key is null.");
                 throw new GarbledDataKeyException();
             }
-        }
-        catch (NoSuchPaddingException | NoSuchAlgorithmException | NoSuchProviderException | InvalidAlgorithmParameterException e) {
+        } catch (NoSuchPaddingException | NoSuchAlgorithmException | NoSuchProviderException | InvalidAlgorithmParameterException e) {
             throw new CryptoImplementationSupplierException(e);
-        }
-        catch (InvalidKeyException e) {
+        } catch (InvalidKeyException e) {
             LOGGER.warn("Invalid key: {}", e.getMessage(), e);
             throw new GarbledDataKeyException();
-        }
-        catch (CFM2Exception e) {
+        } catch (CFM2Exception e) {
             String message = "Failed to decrypt key, retry will be attempted unless max attempts reached";
             LOGGER.warn("Failed to decrypt key: '{}', '{}', '{}'", e.getMessage(), e.getStatus(), e.getClass().getSimpleName());
             LOGGER.warn(message);
@@ -133,8 +128,7 @@ public class WrappingCaviumCryptoImplementationSupplier implements CryptoImpleme
         try {
             LOGGER.debug("Deleting session key.");
             Util.deleteKey((CaviumKey) datakey);
-        }
-        catch (CFM2Exception e) {
+        } catch (CFM2Exception e) {
             LOGGER.error("Failed to delete datakey: '" + e.getMessage() + "'", e);
         }
 

--- a/src/main/java/uk/gov/dwp/dataworks/provider/hsm/WrappingCaviumCryptoImplementationSupplierDefaultAlgorithm.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/hsm/WrappingCaviumCryptoImplementationSupplierDefaultAlgorithm.java
@@ -18,12 +18,9 @@ import uk.gov.dwp.dataworks.errors.GarbledDataKeyException;
 import uk.gov.dwp.dataworks.errors.MasterKeystoreException;
 
 import javax.crypto.Cipher;
-import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.KeyGenerator;
-import javax.crypto.NoSuchPaddingException;
 import java.io.IOException;
 import java.security.*;
-import java.util.Arrays;
 import java.util.Base64;
 
 @Profile("WrappingCaviumDefaultAlgorithm")
@@ -35,8 +32,7 @@ public class WrappingCaviumCryptoImplementationSupplierDefaultAlgorithm
     static {
         try {
             Security.addProvider(new CaviumProvider());
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             throw new RuntimeException("Cavium provider not available: '" + e.getMessage() + "'", e);
         }
     }
@@ -49,8 +45,7 @@ public class WrappingCaviumCryptoImplementationSupplierDefaultAlgorithm
                     new CaviumAESKeyGenParameterSpec(128, DATA_KEY_LABEL, EXTRACTABLE, NOT_PERSISTENT);
             keyGenerator.init(aesSpec);
             return keyGenerator.generateKey();
-        }
-        catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidAlgorithmParameterException e) {
+        } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidAlgorithmParameterException e) {
             LOGGER.error("Failed to create data key", e);
             throw new CryptoImplementationSupplierException(e);
         }
@@ -62,14 +57,12 @@ public class WrappingCaviumCryptoImplementationSupplierDefaultAlgorithm
             throws CryptoImplementationSupplierException, MasterKeystoreException {
         try {
             byte[] keyAttribute = Util.getKeyAttributes(wrappingKeyHandle);
-            CaviumRSAPublicKey publicKey = new CaviumRSAPublicKey(wrappingKeyHandle,  new CaviumKeyAttributes(keyAttribute));
+            CaviumRSAPublicKey publicKey = new CaviumRSAPublicKey(wrappingKeyHandle, new CaviumKeyAttributes(keyAttribute));
             byte[] wrappedKey = Util.rsaWrapKey(publicKey, (CaviumKey) dataKey, PADDING);
             return Base64.getEncoder().encode(wrappedKey);
-        }
-        catch (InvalidKeyException e) {
+        } catch (InvalidKeyException e) {
             throw new CryptoImplementationSupplierException(e);
-        }
-        catch (CFM2Exception e) {
+        } catch (CFM2Exception e) {
             String message = "Failed to encrypt key, retry will be attempted unless max attempts reached";
             LOGGER.warn(message);
             throw new MasterKeystoreException(message, e);
@@ -100,22 +93,17 @@ public class WrappingCaviumCryptoImplementationSupplierDefaultAlgorithm
                     LOGGER.debug("Removing unwrapped session key.");
                     cleanupKey(unwrappedKey);
                     return new String(Base64.getEncoder().encode(exportedUnwrappedKey));
-                }
-                else {
+                } else {
                     throw new GarbledDataKeyException();
                 }
-            }
-            else {
+            } else {
                 throw new GarbledDataKeyException();
             }
-        }
-        catch (NoSuchAlgorithmException e) {
+        } catch (NoSuchAlgorithmException e) {
             throw new CryptoImplementationSupplierException(e);
-        }
-        catch (InvalidKeyException e) {
+        } catch (InvalidKeyException e) {
             throw new GarbledDataKeyException();
-        }
-        catch (CFM2Exception e) {
+        } catch (CFM2Exception e) {
             String message = "Failed to decrypt key, retry will be attempted unless max attempts reached";
             LOGGER.warn("Failed to decrypt key: '{}', '{}', '{}'", e.getMessage(), e.getStatus(), e.getClass().getSimpleName());
             LOGGER.warn(message);
@@ -129,8 +117,7 @@ public class WrappingCaviumCryptoImplementationSupplierDefaultAlgorithm
         try {
             LOGGER.debug("Deleting session key.");
             Util.deleteKey((CaviumKey) datakey);
-        }
-        catch (CFM2Exception e) {
+        } catch (CFM2Exception e) {
             LOGGER.error("Failed to delete datakey: '" + e.getMessage() + "'", e);
         }
     }

--- a/src/main/java/uk/gov/dwp/dataworks/provider/hsm/WrappingCaviumCryptoImplementationSupplierDefaultAlgorithm.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/hsm/WrappingCaviumCryptoImplementationSupplierDefaultAlgorithm.java
@@ -102,7 +102,7 @@ public class WrappingCaviumCryptoImplementationSupplierDefaultAlgorithm
         } catch (InvalidKeyException e) {
             throw new GarbledDataKeyException(correlationId);
         } catch (CFM2Exception e) {
-            LOGGER.warn("Failed to decrypt key: '{}', '{}', '{}'", e.getMessage(), e.getStatus(), e.getClass().getSimpleName());
+            LOGGER.warn("Failed to decrypt key: '{}', '{}', '{}'. correlation_id= {}", e.getMessage(), e.getStatus(), e.getClass().getSimpleName(), correlationId);
             String message = "Failed to decrypt key, retry will be attempted unless max attempts reached. correlation_id: " + correlationId;
             LOGGER.warn(message);
             throw new MasterKeystoreException(message, e);

--- a/src/main/java/uk/gov/dwp/dataworks/provider/kms/KMSDataKeyDecryptionProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/kms/KMSDataKeyDecryptionProvider.java
@@ -33,11 +33,11 @@ public class KMSDataKeyDecryptionProvider implements DataKeyDecryptionProvider {
         this.awsKms = awsKms;
     }
 
-    public DecryptDataKeyResponse decryptDataKey(String keyId, String ciphertextDataKey, String dksCorrelationId) {
+    public DecryptDataKeyResponse decryptDataKey(String keyId, String ciphertextDataKey, String correlationId) {
         try {
             if (Strings.isNullOrEmpty(keyId) || Strings.isNullOrEmpty(ciphertextDataKey) ||
                     ciphertextDataKey.getBytes().length > DataKeyDecryptionProvider.MAX_PAYLOAD_SIZE) {
-                throw new UnusableParameterException();
+                throw new UnusableParameterException(correlationId);
             }
 
             ByteBuffer ciphertextDataKeyBuffer = ByteBuffer.wrap(decoder.decode(ciphertextDataKey));
@@ -46,16 +46,16 @@ public class KMSDataKeyDecryptionProvider implements DataKeyDecryptionProvider {
             return new DecryptDataKeyResponse(result.getKeyId(),
                     encoder.encodeToString(result.getPlaintext().array()));
         } catch (UnusableParameterException e) {
-            LOGGER.error("The supplied key or cyphertext are unusable.", e);
+            LOGGER.error(e.getMessage(), e);
             throw e;
         } catch (IllegalArgumentException | InvalidCiphertextException ex) {
-
-            LOGGER.error("The supplied data key could not be decrypted. " +
-                    "Either the ciphertext is invalid or the data key encryption key is incorrect.", ex);
-            throw new GarbledDataKeyException();
+            GarbledDataKeyException wrapper = new GarbledDataKeyException(correlationId);
+            LOGGER.error(wrapper.getMessage(), ex);
+            throw wrapper;
         } catch (RuntimeException ex) {
-            LOGGER.error("Failed to decrypt this data key due to an internal error. Try again later.", ex);
-            throw new DataKeyDecryptionException();
+            DataKeyDecryptionException wrapper = new DataKeyDecryptionException(correlationId);
+            LOGGER.error(wrapper.getMessage(), ex);
+            throw wrapper;
         }
     }
 

--- a/src/main/java/uk/gov/dwp/dataworks/provider/kms/KMSDataKeyDecryptionProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/kms/KMSDataKeyDecryptionProvider.java
@@ -33,7 +33,7 @@ public class KMSDataKeyDecryptionProvider implements DataKeyDecryptionProvider {
         this.awsKms = awsKms;
     }
 
-    public DecryptDataKeyResponse decryptDataKey(String keyId, String ciphertextDataKey) {
+    public DecryptDataKeyResponse decryptDataKey(String keyId, String ciphertextDataKey, String dksCorrelationId) {
         try {
             if (Strings.isNullOrEmpty(keyId) || Strings.isNullOrEmpty(ciphertextDataKey) ||
                     ciphertextDataKey.getBytes().length > DataKeyDecryptionProvider.MAX_PAYLOAD_SIZE) {
@@ -45,18 +45,15 @@ public class KMSDataKeyDecryptionProvider implements DataKeyDecryptionProvider {
             DecryptResult result = this.awsKms.decrypt(request);
             return new DecryptDataKeyResponse(result.getKeyId(),
                     encoder.encodeToString(result.getPlaintext().array()));
-        }
-        catch (UnusableParameterException e) {
+        } catch (UnusableParameterException e) {
             LOGGER.error("The supplied key or cyphertext are unusable.", e);
             throw e;
-        }
-        catch (IllegalArgumentException | InvalidCiphertextException ex) {
+        } catch (IllegalArgumentException | InvalidCiphertextException ex) {
 
             LOGGER.error("The supplied data key could not be decrypted. " +
                     "Either the ciphertext is invalid or the data key encryption key is incorrect.", ex);
             throw new GarbledDataKeyException();
-        }
-        catch (RuntimeException ex) {
+        } catch (RuntimeException ex) {
             LOGGER.error("Failed to decrypt this data key due to an internal error. Try again later.", ex);
             throw new DataKeyDecryptionException();
         }

--- a/src/main/java/uk/gov/dwp/dataworks/provider/kms/KMSDataKeyGeneratorProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/kms/KMSDataKeyGeneratorProvider.java
@@ -25,7 +25,7 @@ public class KMSDataKeyGeneratorProvider implements DataKeyGeneratorProvider {
     }
 
     @Override
-    public GenerateDataKeyResponse generateDataKey(String encryptionKeyId, String dksCorrelationId) throws DataKeyGenerationException {
+    public GenerateDataKeyResponse generateDataKey(String encryptionKeyId, String correlationId) throws DataKeyGenerationException {
         try {
             Base64.Encoder encoder = Base64.getEncoder();
             GenerateDataKeyRequest dataKeyRequest = new GenerateDataKeyRequest();
@@ -36,8 +36,9 @@ public class KMSDataKeyGeneratorProvider implements DataKeyGeneratorProvider {
                     encoder.encodeToString(result.getCiphertextBlob().array()));
         }
         catch (NotFoundException | DisabledException | KeyUnavailableException | DependencyTimeoutException | InvalidKeyUsageException | InvalidGrantTokenException | KMSInternalException | KMSInvalidStateException ex) {
-            LOGGER.error("Failed to generate a new data key due to an internal error. Try again later.", ex);
-            throw new DataKeyGenerationException();
+            DataKeyGenerationException wrapper = new DataKeyGenerationException(correlationId);
+            LOGGER.error(wrapper.getMessage(), ex);
+            throw wrapper;
         }
     }
 

--- a/src/main/java/uk/gov/dwp/dataworks/provider/kms/KMSDataKeyGeneratorProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/kms/KMSDataKeyGeneratorProvider.java
@@ -25,7 +25,7 @@ public class KMSDataKeyGeneratorProvider implements DataKeyGeneratorProvider {
     }
 
     @Override
-    public GenerateDataKeyResponse generateDataKey(String encryptionKeyId) throws DataKeyGenerationException {
+    public GenerateDataKeyResponse generateDataKey(String encryptionKeyId, String dksCorrelationId) throws DataKeyGenerationException {
         try {
             Base64.Encoder encoder = Base64.getEncoder();
             GenerateDataKeyRequest dataKeyRequest = new GenerateDataKeyRequest();

--- a/src/main/java/uk/gov/dwp/dataworks/provider/standalone/StandaloneCurrentKeyIdProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/standalone/StandaloneCurrentKeyIdProvider.java
@@ -10,7 +10,7 @@ import uk.gov.dwp.dataworks.provider.CurrentKeyIdProvider;
 public class StandaloneCurrentKeyIdProvider implements CurrentKeyIdProvider {
 
     @Override
-    public String getKeyId() throws CurrentKeyIdException {
+    public String getKeyId(String dksCorrelationId) throws CurrentKeyIdException {
         return "STANDALONE";
     }
 

--- a/src/main/java/uk/gov/dwp/dataworks/provider/standalone/StandaloneCurrentKeyIdProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/standalone/StandaloneCurrentKeyIdProvider.java
@@ -10,7 +10,7 @@ import uk.gov.dwp.dataworks.provider.CurrentKeyIdProvider;
 public class StandaloneCurrentKeyIdProvider implements CurrentKeyIdProvider {
 
     @Override
-    public String getKeyId(String dksCorrelationId) throws CurrentKeyIdException {
+    public String getKeyId(String correlationId) throws CurrentKeyIdException {
         return "STANDALONE";
     }
 

--- a/src/main/java/uk/gov/dwp/dataworks/provider/standalone/StandaloneDataKeyDecryptionProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/standalone/StandaloneDataKeyDecryptionProvider.java
@@ -22,7 +22,7 @@ public class StandaloneDataKeyDecryptionProvider implements DataKeyDecryptionPro
     }
 
     @Override
-    public DecryptDataKeyResponse decryptDataKey(String dataKeyEncryptionKeyId, String ciphertextDataKey, String dksCorrelationId) {
+    public DecryptDataKeyResponse decryptDataKey(String dataKeyEncryptionKeyId, String ciphertextDataKey, String correlationId) {
         ByteBuffer ciphertextDataKeyBuffer = ByteBuffer.wrap(decoder.decode(ciphertextDataKey));
         byte[] decrypted = ciphertextDataKeyBuffer.array();
         ArrayUtils.reverse(decrypted);

--- a/src/main/java/uk/gov/dwp/dataworks/provider/standalone/StandaloneDataKeyDecryptionProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/standalone/StandaloneDataKeyDecryptionProvider.java
@@ -17,12 +17,12 @@ public class StandaloneDataKeyDecryptionProvider implements DataKeyDecryptionPro
     private final Base64.Decoder decoder = Base64.getDecoder();
 
     @Autowired
-    public StandaloneDataKeyDecryptionProvider(){
+    public StandaloneDataKeyDecryptionProvider() {
 
     }
 
     @Override
-    public DecryptDataKeyResponse decryptDataKey(String dataKeyEncryptionKeyId, String ciphertextDataKey) {
+    public DecryptDataKeyResponse decryptDataKey(String dataKeyEncryptionKeyId, String ciphertextDataKey, String dksCorrelationId) {
         ByteBuffer ciphertextDataKeyBuffer = ByteBuffer.wrap(decoder.decode(ciphertextDataKey));
         byte[] decrypted = ciphertextDataKeyBuffer.array();
         ArrayUtils.reverse(decrypted);

--- a/src/main/java/uk/gov/dwp/dataworks/provider/standalone/StandaloneDataKeyGeneratorProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/standalone/StandaloneDataKeyGeneratorProvider.java
@@ -21,7 +21,7 @@ public class StandaloneDataKeyGeneratorProvider implements DataKeyGeneratorProvi
     }
 
     @Override
-    public GenerateDataKeyResponse generateDataKey(String keyId, String dksCorrelationId) {
+    public GenerateDataKeyResponse generateDataKey(String keyId, String correlationId) {
 
         // Generate a random key
         int keySize = 128 / 8;

--- a/src/main/java/uk/gov/dwp/dataworks/provider/standalone/StandaloneDataKeyGeneratorProvider.java
+++ b/src/main/java/uk/gov/dwp/dataworks/provider/standalone/StandaloneDataKeyGeneratorProvider.java
@@ -16,15 +16,15 @@ public class StandaloneDataKeyGeneratorProvider implements DataKeyGeneratorProvi
     private final Base64.Encoder encoder = Base64.getEncoder();
 
     @Autowired
-    public StandaloneDataKeyGeneratorProvider(){
+    public StandaloneDataKeyGeneratorProvider() {
 
     }
 
     @Override
-    public GenerateDataKeyResponse generateDataKey(String keyId) {
+    public GenerateDataKeyResponse generateDataKey(String keyId, String dksCorrelationId) {
 
         // Generate a random key
-        int keySize = 128/8;
+        int keySize = 128 / 8;
         byte[] key = new byte[keySize];
         new Random().nextBytes(key);
         String plaintextKey = encoder.encodeToString(key);

--- a/src/main/java/uk/gov/dwp/dataworks/service/DataKeyService.java
+++ b/src/main/java/uk/gov/dwp/dataworks/service/DataKeyService.java
@@ -34,8 +34,8 @@ public class DataKeyService {
     }
 
     @Cacheable(value = KEY_CACHE, key = "#root.methodName")
-    public String currentKeyId() {
-        return currentKeyIdProvider.getKeyId();
+    public String currentKeyId(String dksCorrelationId) {
+        return currentKeyIdProvider.getKeyId(dksCorrelationId);
     }
 
     @Scheduled(fixedRateString = "${key.cache.eviction.interval:120000}")
@@ -45,12 +45,12 @@ public class DataKeyService {
     }
 
     public GenerateDataKeyResponse generate(String keyId, String dksCorrelationId) throws LoginException, MasterKeystoreException {
-        return dataKeyProvider.generateDataKey(keyId);
+        return dataKeyProvider.generateDataKey(keyId, dksCorrelationId);
     }
 
     public DecryptDataKeyResponse decrypt(String dataKeyId, String ciphertextDataKey, String dksCorrelationId)
             throws LoginException, MasterKeystoreException {
-        return dataKeyDecryptionProvider.decryptDataKey(dataKeyId, ciphertextDataKey);
+        return dataKeyDecryptionProvider.decryptDataKey(dataKeyId, ciphertextDataKey, dksCorrelationId);
     }
 
     public boolean canSeeDependencies() throws MasterKeystoreException {

--- a/src/main/java/uk/gov/dwp/dataworks/service/DataKeyService.java
+++ b/src/main/java/uk/gov/dwp/dataworks/service/DataKeyService.java
@@ -44,12 +44,12 @@ public class DataKeyService {
         LOGGER.debug("Key cache evicted.");
     }
 
-    public GenerateDataKeyResponse generate(String keyId) throws LoginException, MasterKeystoreException {
+    public GenerateDataKeyResponse generate(String keyId, String dksCorrelationId) throws LoginException, MasterKeystoreException {
 
         return dataKeyProvider.generateDataKey(keyId);
     }
 
-    public DecryptDataKeyResponse decrypt(String dataKeyId, String ciphertextDataKey)
+    public DecryptDataKeyResponse decrypt(String dataKeyId, String ciphertextDataKey, String dksCorrelationId)
             throws LoginException, MasterKeystoreException {
         return dataKeyDecryptionProvider.decryptDataKey(dataKeyId, ciphertextDataKey);
     }

--- a/src/main/java/uk/gov/dwp/dataworks/service/DataKeyService.java
+++ b/src/main/java/uk/gov/dwp/dataworks/service/DataKeyService.java
@@ -45,7 +45,6 @@ public class DataKeyService {
     }
 
     public GenerateDataKeyResponse generate(String keyId, String dksCorrelationId) throws LoginException, MasterKeystoreException {
-
         return dataKeyProvider.generateDataKey(keyId);
     }
 

--- a/src/main/java/uk/gov/dwp/dataworks/service/DataKeyService.java
+++ b/src/main/java/uk/gov/dwp/dataworks/service/DataKeyService.java
@@ -34,8 +34,8 @@ public class DataKeyService {
     }
 
     @Cacheable(value = KEY_CACHE, key = "#root.methodName")
-    public String currentKeyId(String dksCorrelationId) {
-        return currentKeyIdProvider.getKeyId(dksCorrelationId);
+    public String currentKeyId(String correlationId) {
+        return currentKeyIdProvider.getKeyId(correlationId);
     }
 
     @Scheduled(fixedRateString = "${key.cache.eviction.interval:120000}")
@@ -44,13 +44,13 @@ public class DataKeyService {
         LOGGER.debug("Key cache evicted.");
     }
 
-    public GenerateDataKeyResponse generate(String keyId, String dksCorrelationId) throws LoginException, MasterKeystoreException {
-        return dataKeyProvider.generateDataKey(keyId, dksCorrelationId);
+    public GenerateDataKeyResponse generate(String keyId, String correlationId) throws LoginException, MasterKeystoreException {
+        return dataKeyProvider.generateDataKey(keyId, correlationId);
     }
 
-    public DecryptDataKeyResponse decrypt(String dataKeyId, String ciphertextDataKey, String dksCorrelationId)
+    public DecryptDataKeyResponse decrypt(String dataKeyId, String ciphertextDataKey, String correlationId)
             throws LoginException, MasterKeystoreException {
-        return dataKeyDecryptionProvider.decryptDataKey(dataKeyId, ciphertextDataKey, dksCorrelationId);
+        return dataKeyDecryptionProvider.decryptDataKey(dataKeyId, ciphertextDataKey, correlationId);
     }
 
     public boolean canSeeDependencies() throws MasterKeystoreException {

--- a/src/main/java/uk/gov/dwp/dataworks/service/HealthCheckService.java
+++ b/src/main/java/uk/gov/dwp/dataworks/service/HealthCheckService.java
@@ -8,12 +8,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import uk.gov.dwp.dataworks.controller.HealthCheckController;
 import uk.gov.dwp.dataworks.dto.HealthCheckResponse;
+import static java.util.UUID.randomUUID;
 
 @Service
 @ConditionalOnProperty(value = "scheduling.enabled", havingValue = "true", matchIfMissing = true)
@@ -28,16 +28,17 @@ public class HealthCheckService {
 
     @Scheduled(initialDelay = 1000, fixedRateString = "${healthcheck.interval:10000}")
     public void logHealthCheck() {
-        ResponseEntity<HealthCheckResponse> response = healthCheckController.healthCheck();
+        String correlationId = randomUUID().toString();
+        ResponseEntity<HealthCheckResponse> response = healthCheckController.healthCheck(correlationId);
         JsonFactory factory = new MappingJsonFactory();
         ObjectMapper mapper = new ObjectMapper(factory);
         ObjectNode responseBody = mapper.valueToTree(response.getBody());
         responseBody.remove("trustedCertificates");
         if(response.getStatusCode().value() == 200) {
-            LOGGER.info("HEALTHCHECK: {}", responseBody);
+            LOGGER.info("HEALTHCHECK: {}, dks_correlation_id: {}", responseBody, correlationId);
         }
         else {
-            LOGGER.warn("HEALTHCHECK {}", responseBody);
+            LOGGER.warn("HEALTHCHECK: {}, dks_correlation_id: {}", responseBody, correlationId);
         }
     }
 }

--- a/src/main/java/uk/gov/dwp/dataworks/service/HealthCheckService.java
+++ b/src/main/java/uk/gov/dwp/dataworks/service/HealthCheckService.java
@@ -35,10 +35,10 @@ public class HealthCheckService {
         ObjectNode responseBody = mapper.valueToTree(response.getBody());
         responseBody.remove("trustedCertificates");
         if(response.getStatusCode().value() == 200) {
-            LOGGER.info("HEALTHCHECK: {}, dks_correlation_id: {}", responseBody, correlationId);
+            LOGGER.info("HEALTHCHECK: {}, correlation_id: {}", responseBody, correlationId);
         }
         else {
-            LOGGER.warn("HEALTHCHECK: {}, dks_correlation_id: {}", responseBody, correlationId);
+            LOGGER.warn("HEALTHCHECK: {}, correlation_id: {}", responseBody, correlationId);
         }
     }
 }

--- a/src/test/java/uk/gov/dwp/dataworks/controller/DataKeyControllerTest.java
+++ b/src/test/java/uk/gov/dwp/dataworks/controller/DataKeyControllerTest.java
@@ -19,7 +19,7 @@ public class DataKeyControllerTest {
         dataKeyController.generate(dksCorrelationId);
 
         verify(mockDataKeyService, times(1)).currentKeyId();
-        verify(mockDataKeyService, times(1)).generate(eq(keyId));
+        verify(mockDataKeyService, times(1)).generate(eq(keyId), eq(dksCorrelationId));
         verifyNoMoreInteractions(mockDataKeyService);
     }
 
@@ -33,7 +33,7 @@ public class DataKeyControllerTest {
 
         dataKeyController.decrypt(keyId, dksCorrelationId, ciphertextDataKey);
 
-        verify(mockDataKeyService, times(1)).decrypt(keyId, ciphertextDataKey);
+        verify(mockDataKeyService, times(1)).decrypt(eq(keyId), eq(ciphertextDataKey), eq(dksCorrelationId));
         verifyNoMoreInteractions(mockDataKeyService);
     }
 }

--- a/src/test/java/uk/gov/dwp/dataworks/controller/DataKeyControllerTest.java
+++ b/src/test/java/uk/gov/dwp/dataworks/controller/DataKeyControllerTest.java
@@ -9,14 +9,31 @@ import static org.mockito.Mockito.*;
 public class DataKeyControllerTest {
 
     @Test
+    public void generateWillPassParametersToTheDataKeyService() throws MasterKeystoreException {
+        DataKeyService mockDataKeyService = mock(DataKeyService.class);
+        DataKeyController dataKeyController = new DataKeyController(mockDataKeyService);
+        String keyId = "I am a key Id";
+        String dksCorrelationId = "aaa111";
+        when(mockDataKeyService.currentKeyId()).thenReturn(keyId);
+
+        dataKeyController.generate(dksCorrelationId);
+
+        verify(mockDataKeyService, times(1)).currentKeyId();
+        verify(mockDataKeyService, times(1)).generate(eq(keyId));
+        verifyNoMoreInteractions(mockDataKeyService);
+    }
+
+    @Test
     public void decryptWillPassParametersToTheDataKeyService() throws MasterKeystoreException {
-        DataKeyService dataKeyService = mock(DataKeyService.class);
-        DataKeyController dataKeyController = new DataKeyController(dataKeyService);
+        DataKeyService mockDataKeyService = mock(DataKeyService.class);
+        DataKeyController dataKeyController = new DataKeyController(mockDataKeyService);
         String keyId = "I am a key Id";
         String ciphertextDataKey = "I am a ciphertext Data Key";
+        String dksCorrelationId = "aaa111";
 
-        dataKeyController.decrypt(keyId, ciphertextDataKey);
+        dataKeyController.decrypt(keyId, dksCorrelationId, ciphertextDataKey);
 
-        verify(dataKeyService, times(1)).decrypt(keyId, ciphertextDataKey);
+        verify(mockDataKeyService, times(1)).decrypt(keyId, ciphertextDataKey);
+        verifyNoMoreInteractions(mockDataKeyService);
     }
 }

--- a/src/test/java/uk/gov/dwp/dataworks/controller/DataKeyControllerTest.java
+++ b/src/test/java/uk/gov/dwp/dataworks/controller/DataKeyControllerTest.java
@@ -8,18 +8,19 @@ import static org.mockito.Mockito.*;
 
 public class DataKeyControllerTest {
 
+    private final String correlationId = "correlation";
+
     @Test
     public void generateWillPassParametersToTheDataKeyService() throws MasterKeystoreException {
         DataKeyService mockDataKeyService = mock(DataKeyService.class);
         DataKeyController dataKeyController = new DataKeyController(mockDataKeyService);
         String keyId = "I am a key Id";
-        String dksCorrelationId = "aaa111";
-        when(mockDataKeyService.currentKeyId()).thenReturn(keyId);
+        when(mockDataKeyService.currentKeyId(correlationId)).thenReturn(keyId);
 
-        dataKeyController.generate(dksCorrelationId);
+        dataKeyController.generate(correlationId);
 
-        verify(mockDataKeyService, times(1)).currentKeyId();
-        verify(mockDataKeyService, times(1)).generate(eq(keyId), eq(dksCorrelationId));
+        verify(mockDataKeyService, times(1)).currentKeyId(eq(correlationId));
+        verify(mockDataKeyService, times(1)).generate(eq(keyId), eq(correlationId));
         verifyNoMoreInteractions(mockDataKeyService);
     }
 
@@ -29,11 +30,9 @@ public class DataKeyControllerTest {
         DataKeyController dataKeyController = new DataKeyController(mockDataKeyService);
         String keyId = "I am a key Id";
         String ciphertextDataKey = "I am a ciphertext Data Key";
-        String dksCorrelationId = "aaa111";
+        dataKeyController.decrypt(keyId, correlationId, ciphertextDataKey);
 
-        dataKeyController.decrypt(keyId, dksCorrelationId, ciphertextDataKey);
-
-        verify(mockDataKeyService, times(1)).decrypt(eq(keyId), eq(ciphertextDataKey), eq(dksCorrelationId));
+        verify(mockDataKeyService, times(1)).decrypt(eq(keyId), eq(ciphertextDataKey), eq(correlationId));
         verifyNoMoreInteractions(mockDataKeyService);
     }
 }

--- a/src/test/java/uk/gov/dwp/dataworks/dto/DecryptDataKeyResponseTest.java
+++ b/src/test/java/uk/gov/dwp/dataworks/dto/DecryptDataKeyResponseTest.java
@@ -14,16 +14,16 @@ public class DecryptDataKeyResponseTest {
         assertEquals(response1.toString(), response2.toString());
         assertEquals(response1.hashCode(), response2.hashCode());
 
-        response1.setcorrelationId("correlation-1");
-        response2.setcorrelationId("correlation-2");
+        response1.setCorrelationId("correlation-1");
+        response2.setCorrelationId("correlation-2");
 
         assertEquals(response1, response2);
         assertEquals(response1.toString(), response2.toString());
         assertEquals(response1.hashCode(), response2.hashCode());
 
         DecryptDataKeyResponse response3 = new DecryptDataKeyResponse("keyX", "valueX");
-        response1.setcorrelationId("correlation-X");
-        response3.setcorrelationId(response1.getcorrelationId());
+        response1.setCorrelationId("correlation-X");
+        response3.setCorrelationId(response1.getCorrelationId());
 
         assertNotEquals(response1, response3);
         assertNotEquals(response1.toString(), response3.toString());

--- a/src/test/java/uk/gov/dwp/dataworks/dto/DecryptDataKeyResponseTest.java
+++ b/src/test/java/uk/gov/dwp/dataworks/dto/DecryptDataKeyResponseTest.java
@@ -1,0 +1,33 @@
+package uk.gov.dwp.dataworks.dto;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+public class DecryptDataKeyResponseTest {
+
+    @Test
+    public void testThatDksCorrelationIdIsNotInEquality()  {
+        DecryptDataKeyResponse response1 = new DecryptDataKeyResponse("key", "value");
+        DecryptDataKeyResponse response2 = new DecryptDataKeyResponse("key", "value");
+
+        assertEquals(response1, response2);
+        assertEquals(response1.toString(), response2.toString());
+        assertEquals(response1.hashCode(), response2.hashCode());
+
+        response1.setDksCorrelationId("correlation-1");
+        response2.setDksCorrelationId("correlation-2");
+
+        assertEquals(response1, response2);
+        assertEquals(response1.toString(), response2.toString());
+        assertEquals(response1.hashCode(), response2.hashCode());
+
+        DecryptDataKeyResponse response3 = new DecryptDataKeyResponse("keyX", "valueX");
+        response1.setDksCorrelationId("correlation-X");
+        response3.setDksCorrelationId(response1.getDksCorrelationId());
+
+        assertNotEquals(response1, response3);
+        assertNotEquals(response1.toString(), response3.toString());
+        assertNotEquals(response1.hashCode(), response3.hashCode());
+    }
+
+}

--- a/src/test/java/uk/gov/dwp/dataworks/dto/DecryptDataKeyResponseTest.java
+++ b/src/test/java/uk/gov/dwp/dataworks/dto/DecryptDataKeyResponseTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 public class DecryptDataKeyResponseTest {
 
     @Test
-    public void testThatDksCorrelationIdIsNotInEquality()  {
+    public void testThatcorrelationIdIsNotInEquality()  {
         DecryptDataKeyResponse response1 = new DecryptDataKeyResponse("key", "value");
         DecryptDataKeyResponse response2 = new DecryptDataKeyResponse("key", "value");
 
@@ -14,16 +14,16 @@ public class DecryptDataKeyResponseTest {
         assertEquals(response1.toString(), response2.toString());
         assertEquals(response1.hashCode(), response2.hashCode());
 
-        response1.setDksCorrelationId("correlation-1");
-        response2.setDksCorrelationId("correlation-2");
+        response1.setcorrelationId("correlation-1");
+        response2.setcorrelationId("correlation-2");
 
         assertEquals(response1, response2);
         assertEquals(response1.toString(), response2.toString());
         assertEquals(response1.hashCode(), response2.hashCode());
 
         DecryptDataKeyResponse response3 = new DecryptDataKeyResponse("keyX", "valueX");
-        response1.setDksCorrelationId("correlation-X");
-        response3.setDksCorrelationId(response1.getDksCorrelationId());
+        response1.setcorrelationId("correlation-X");
+        response3.setcorrelationId(response1.getcorrelationId());
 
         assertNotEquals(response1, response3);
         assertNotEquals(response1.toString(), response3.toString());

--- a/src/test/java/uk/gov/dwp/dataworks/dto/GenerateDataKeyResponseTest.java
+++ b/src/test/java/uk/gov/dwp/dataworks/dto/GenerateDataKeyResponseTest.java
@@ -8,7 +8,7 @@ import static org.junit.Assert.assertNotEquals;
 public class GenerateDataKeyResponseTest {
 
     @Test
-    public void testThatDksCorrelationIdIsNotInEquality()  {
+    public void testThatcorrelationIdIsNotInEquality()  {
         GenerateDataKeyResponse response1 = new GenerateDataKeyResponse("key", "plain", "cypher");
         GenerateDataKeyResponse response2 = new GenerateDataKeyResponse("key", "plain", "cypher");
 
@@ -16,16 +16,16 @@ public class GenerateDataKeyResponseTest {
         assertEquals(response1.toString(), response2.toString());
         assertEquals(response1.hashCode(), response2.hashCode());
 
-        response1.setDksCorrelationId("correlation-1");
-        response2.setDksCorrelationId("correlation-2");
+        response1.setcorrelationId("correlation-1");
+        response2.setcorrelationId("correlation-2");
 
         assertEquals(response1, response2);
         assertEquals(response1.toString(), response2.toString());
         assertEquals(response1.hashCode(), response2.hashCode());
 
         GenerateDataKeyResponse response3 = new GenerateDataKeyResponse("keyX", "valueX", "cypherX");
-        response1.setDksCorrelationId("correlation-X");
-        response3.setDksCorrelationId(response1.getDksCorrelationId());
+        response1.setcorrelationId("correlation-X");
+        response3.setcorrelationId(response1.getcorrelationId());
 
         assertNotEquals(response1, response3);
         assertNotEquals(response1.toString(), response3.toString());

--- a/src/test/java/uk/gov/dwp/dataworks/dto/GenerateDataKeyResponseTest.java
+++ b/src/test/java/uk/gov/dwp/dataworks/dto/GenerateDataKeyResponseTest.java
@@ -1,0 +1,35 @@
+package uk.gov.dwp.dataworks.dto;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class GenerateDataKeyResponseTest {
+
+    @Test
+    public void testThatDksCorrelationIdIsNotInEquality()  {
+        GenerateDataKeyResponse response1 = new GenerateDataKeyResponse("key", "plain", "cypher");
+        GenerateDataKeyResponse response2 = new GenerateDataKeyResponse("key", "plain", "cypher");
+
+        assertEquals(response1, response2);
+        assertEquals(response1.toString(), response2.toString());
+        assertEquals(response1.hashCode(), response2.hashCode());
+
+        response1.setDksCorrelationId("correlation-1");
+        response2.setDksCorrelationId("correlation-2");
+
+        assertEquals(response1, response2);
+        assertEquals(response1.toString(), response2.toString());
+        assertEquals(response1.hashCode(), response2.hashCode());
+
+        GenerateDataKeyResponse response3 = new GenerateDataKeyResponse("keyX", "valueX", "cypherX");
+        response1.setDksCorrelationId("correlation-X");
+        response3.setDksCorrelationId(response1.getDksCorrelationId());
+
+        assertNotEquals(response1, response3);
+        assertNotEquals(response1.toString(), response3.toString());
+        assertNotEquals(response1.hashCode(), response3.hashCode());
+    }
+
+}

--- a/src/test/java/uk/gov/dwp/dataworks/dto/GenerateDataKeyResponseTest.java
+++ b/src/test/java/uk/gov/dwp/dataworks/dto/GenerateDataKeyResponseTest.java
@@ -16,16 +16,16 @@ public class GenerateDataKeyResponseTest {
         assertEquals(response1.toString(), response2.toString());
         assertEquals(response1.hashCode(), response2.hashCode());
 
-        response1.setcorrelationId("correlation-1");
-        response2.setcorrelationId("correlation-2");
+        response1.setCorrelationId("correlation-1");
+        response2.setCorrelationId("correlation-2");
 
         assertEquals(response1, response2);
         assertEquals(response1.toString(), response2.toString());
         assertEquals(response1.hashCode(), response2.hashCode());
 
         GenerateDataKeyResponse response3 = new GenerateDataKeyResponse("keyX", "valueX", "cypherX");
-        response1.setcorrelationId("correlation-X");
-        response3.setcorrelationId(response1.getcorrelationId());
+        response1.setCorrelationId("correlation-X");
+        response3.setCorrelationId(response1.getCorrelationId());
 
         assertNotEquals(response1, response3);
         assertNotEquals(response1.toString(), response3.toString());

--- a/src/test/java/uk/gov/dwp/dataworks/integration/DataKeyIntegrationTests.java
+++ b/src/test/java/uk/gov/dwp/dataworks/integration/DataKeyIntegrationTests.java
@@ -90,7 +90,7 @@ public class DataKeyIntegrationTests {
                 new GenerateDataKeyResponse("encryptionId",
                         "plainKey",
                         "cipherKey")
-                .withcorrelationId(correlationId);
+                .withCorrelationId(correlationId);
 
         given(dataKeyGeneratorProvider.generateDataKey(eq("myKeyId"), eq(correlationId)))
                 .willReturn(response);
@@ -126,7 +126,7 @@ public class DataKeyIntegrationTests {
     public void shouldReturnDecryptedKeyWhenRequestedWithSpecifiedCorrelationId() throws Exception {
         DecryptDataKeyResponse response =
                 new DecryptDataKeyResponse("decryptKeyId", "plaintextDataKey")
-                        .withcorrelationId(correlationId);
+                        .withCorrelationId(correlationId);
 
         String dataKeyEncryptionKeyId = "dataKeyEncryptionKeyId";
         String encryptedDataKey = "blah blah blah";

--- a/src/test/java/uk/gov/dwp/dataworks/integration/DataKeyIntegrationTests.java
+++ b/src/test/java/uk/gov/dwp/dataworks/integration/DataKeyIntegrationTests.java
@@ -35,6 +35,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 public class DataKeyIntegrationTests {
 
+    private final String correlationId = "correlation";
+
     @Autowired
     private CurrentKeyIdProvider currentKeyIdProvider;
 
@@ -59,7 +61,7 @@ public class DataKeyIntegrationTests {
     }
 
     @Test
-    public void shouldReturnADataKeyWhenRequestingKeyGeneration() throws Exception {
+    public void shouldReturnADataKeyWhenRequestingKeyGenerationWithoutSpecifiedCorrelationId() throws Exception {
         given(currentKeyIdProvider.getKeyId(anyString())).willReturn("myKeyId");
 
         GenerateDataKeyResponse response =
@@ -81,7 +83,30 @@ public class DataKeyIntegrationTests {
     }
 
     @Test
-    public void shouldReturnDecryptedKeyWhenRequested() throws Exception {
+    public void shouldReturnADataKeyWhenRequestingKeyGenerationWithSpecifiedCorrelationId() throws Exception {
+        given(currentKeyIdProvider.getKeyId(eq(correlationId))).willReturn("myKeyId");
+
+        GenerateDataKeyResponse response =
+                new GenerateDataKeyResponse("encryptionId",
+                        "plainKey",
+                        "cipherKey")
+                .withDksCorrelationId(correlationId);
+
+        given(dataKeyGeneratorProvider.generateDataKey(eq("myKeyId"), eq(correlationId)))
+                .willReturn(response);
+
+        mockMvc.perform(get("/datakey?dksCorrelationId={correlationId}", correlationId))
+                .andExpect(status().isCreated())
+                .andExpect(content().json(new ObjectMapper().writeValueAsString(response)));
+
+        // Must also allow a trailing slash
+        mockMvc.perform(get("/datakey/?dksCorrelationId={correlationId}", correlationId))
+                .andExpect(status().isCreated())
+                .andExpect(content().json(new ObjectMapper().writeValueAsString(response)));
+    }
+
+    @Test
+    public void shouldReturnDecryptedKeyWhenRequestedWithoutSpecifiedCorrelationId() throws Exception {
         DecryptDataKeyResponse response =
                 new DecryptDataKeyResponse("decryptKeyId",
                         "plaintextDataKey");
@@ -98,15 +123,50 @@ public class DataKeyIntegrationTests {
     }
 
     @Test
-    public void shouldReturnServiceUnavailableWhenCurrentKeyIdIsUnavailable() throws Exception {
+    public void shouldReturnDecryptedKeyWhenRequestedWithSpecifiedCorrelationId() throws Exception {
+        DecryptDataKeyResponse response =
+                new DecryptDataKeyResponse("decryptKeyId", "plaintextDataKey")
+                        .withDksCorrelationId(correlationId);
+
+        String dataKeyEncryptionKeyId = "dataKeyEncryptionKeyId";
+        String encryptedDataKey = "blah blah blah";
+        given(dataKeyDecryptionProvider.decryptDataKey(eq(dataKeyEncryptionKeyId), eq(encryptedDataKey), eq(correlationId)))
+                .willReturn(response);
+
+        mockMvc.perform(post("/datakey/actions/decrypt?keyId={keyId}&dksCorrelationId={correlationId}", dataKeyEncryptionKeyId, correlationId)
+                .content(encryptedDataKey))
+                .andExpect(status().isOk())
+                .andExpect(content().json(new ObjectMapper().writeValueAsString(response)));
+    }
+
+    @Test
+    public void shouldReturnServiceUnavailableWhenCurrentKeyIdIsUnavailableWithoutSpecifiedCorrelationId() throws Exception {
         given(currentKeyIdProvider.getKeyId(anyString())).willThrow(CurrentKeyIdException.class);
+
         mockMvc.perform(get("/datakey")).andExpect(status().isServiceUnavailable());
     }
 
     @Test
-    public void shouldReturnServiceUnavailableWhenDataKeyGenerationFails() throws Exception {
-        given(dataKeyGeneratorProvider.generateDataKey(anyString(), anyString())).willThrow(DataKeyGenerationException.class);
+    public void shouldReturnServiceUnavailableWhenCurrentKeyIdIsUnavailableWithSpecifiedCorrelationId() throws Exception {
+        given(currentKeyIdProvider.getKeyId(eq(correlationId))).willThrow(CurrentKeyIdException.class);
+
+        mockMvc.perform(get("/datakey?dksCorrelationId={correlationId}", correlationId)).andExpect(status().isServiceUnavailable());
+    }
+
+    @Test
+    public void shouldReturnServiceUnavailableWhenDataKeyGenerationFailsWithoutSpecifiedCorrelationId() throws Exception {
+        given(currentKeyIdProvider.getKeyId(anyString())).willReturn("key-id");
+        given(dataKeyGeneratorProvider.generateDataKey(eq("key-id"), anyString())).willThrow(DataKeyGenerationException.class);
+
         mockMvc.perform(get("/datakey")).andExpect(status().isServiceUnavailable());
+    }
+
+    @Test
+    public void shouldReturnServiceUnavailableWhenDataKeyGenerationFailsWithCorrelationId() throws Exception {
+        given(currentKeyIdProvider.getKeyId(eq(correlationId))).willReturn("key-id");
+        given(dataKeyGeneratorProvider.generateDataKey(eq("key-id"), eq(correlationId))).willThrow(DataKeyGenerationException.class);
+
+        mockMvc.perform(get("/datakey?dksCorrelationId={correlationId}", correlationId)).andExpect(status().isServiceUnavailable());
     }
 
     @Test

--- a/src/test/java/uk/gov/dwp/dataworks/integration/DataKeyIntegrationTests.java
+++ b/src/test/java/uk/gov/dwp/dataworks/integration/DataKeyIntegrationTests.java
@@ -90,17 +90,17 @@ public class DataKeyIntegrationTests {
                 new GenerateDataKeyResponse("encryptionId",
                         "plainKey",
                         "cipherKey")
-                .withDksCorrelationId(correlationId);
+                .withcorrelationId(correlationId);
 
         given(dataKeyGeneratorProvider.generateDataKey(eq("myKeyId"), eq(correlationId)))
                 .willReturn(response);
 
-        mockMvc.perform(get("/datakey?dksCorrelationId={correlationId}", correlationId))
+        mockMvc.perform(get("/datakey?correlationId={correlationId}", correlationId))
                 .andExpect(status().isCreated())
                 .andExpect(content().json(new ObjectMapper().writeValueAsString(response)));
 
         // Must also allow a trailing slash
-        mockMvc.perform(get("/datakey/?dksCorrelationId={correlationId}", correlationId))
+        mockMvc.perform(get("/datakey/?correlationId={correlationId}", correlationId))
                 .andExpect(status().isCreated())
                 .andExpect(content().json(new ObjectMapper().writeValueAsString(response)));
     }
@@ -126,14 +126,14 @@ public class DataKeyIntegrationTests {
     public void shouldReturnDecryptedKeyWhenRequestedWithSpecifiedCorrelationId() throws Exception {
         DecryptDataKeyResponse response =
                 new DecryptDataKeyResponse("decryptKeyId", "plaintextDataKey")
-                        .withDksCorrelationId(correlationId);
+                        .withcorrelationId(correlationId);
 
         String dataKeyEncryptionKeyId = "dataKeyEncryptionKeyId";
         String encryptedDataKey = "blah blah blah";
         given(dataKeyDecryptionProvider.decryptDataKey(eq(dataKeyEncryptionKeyId), eq(encryptedDataKey), eq(correlationId)))
                 .willReturn(response);
 
-        mockMvc.perform(post("/datakey/actions/decrypt?keyId={keyId}&dksCorrelationId={correlationId}", dataKeyEncryptionKeyId, correlationId)
+        mockMvc.perform(post("/datakey/actions/decrypt?keyId={keyId}&correlationId={correlationId}", dataKeyEncryptionKeyId, correlationId)
                 .content(encryptedDataKey))
                 .andExpect(status().isOk())
                 .andExpect(content().json(new ObjectMapper().writeValueAsString(response)));
@@ -150,7 +150,7 @@ public class DataKeyIntegrationTests {
     public void shouldReturnServiceUnavailableWhenCurrentKeyIdIsUnavailableWithSpecifiedCorrelationId() throws Exception {
         given(currentKeyIdProvider.getKeyId(eq(correlationId))).willThrow(CurrentKeyIdException.class);
 
-        mockMvc.perform(get("/datakey?dksCorrelationId={correlationId}", correlationId)).andExpect(status().isServiceUnavailable());
+        mockMvc.perform(get("/datakey?correlationId={correlationId}", correlationId)).andExpect(status().isServiceUnavailable());
     }
 
     @Test
@@ -166,7 +166,7 @@ public class DataKeyIntegrationTests {
         given(currentKeyIdProvider.getKeyId(eq(correlationId))).willReturn("key-id");
         given(dataKeyGeneratorProvider.generateDataKey(eq("key-id"), eq(correlationId))).willThrow(DataKeyGenerationException.class);
 
-        mockMvc.perform(get("/datakey?dksCorrelationId={correlationId}", correlationId)).andExpect(status().isServiceUnavailable());
+        mockMvc.perform(get("/datakey?correlationId={correlationId}", correlationId)).andExpect(status().isServiceUnavailable());
     }
 
     @Test

--- a/src/test/java/uk/gov/dwp/dataworks/integration/HealthCheckIntegrationTests.java
+++ b/src/test/java/uk/gov/dwp/dataworks/integration/HealthCheckIntegrationTests.java
@@ -162,7 +162,7 @@ public class HealthCheckIntegrationTests {
         given(currentKeyIdProvider.getKeyId(anyString())).willReturn(ENCRYPTION_KEY_ID);
         GenerateDataKeyResponse response =
                 new GenerateDataKeyResponse(ENCRYPTION_KEY_ID, PLAIN_TEXT_KEY, CIPHER_TEXT_DATA_KEY)
-                .withcorrelationId(correlationId);
+                .withCorrelationId(correlationId);
 
         given(dataKeyGeneratorProvider.generateDataKey(ENCRYPTION_KEY_ID, correlationId)).willReturn(response);
 
@@ -174,7 +174,7 @@ public class HealthCheckIntegrationTests {
                 HealthCheckResponse.Health.OK,
                 HealthCheckResponse.Health.OK,
                 HealthCheckResponse.Health.BAD)
-                .withcorrelationId(correlationId);
+                .withCorrelationId(correlationId);
 
         mockMvc.perform(get(HEALTHCHECK_ENDPOINT + "?correlationId={correlationId}", correlationId))
                 .andExpect(content().json(new ObjectMapper().writeValueAsString(healthCheckResponse)))

--- a/src/test/java/uk/gov/dwp/dataworks/integration/HealthCheckIntegrationTests.java
+++ b/src/test/java/uk/gov/dwp/dataworks/integration/HealthCheckIntegrationTests.java
@@ -162,7 +162,7 @@ public class HealthCheckIntegrationTests {
         given(currentKeyIdProvider.getKeyId(anyString())).willReturn(ENCRYPTION_KEY_ID);
         GenerateDataKeyResponse response =
                 new GenerateDataKeyResponse(ENCRYPTION_KEY_ID, PLAIN_TEXT_KEY, CIPHER_TEXT_DATA_KEY)
-                .withDksCorrelationId(correlationId);
+                .withcorrelationId(correlationId);
 
         given(dataKeyGeneratorProvider.generateDataKey(ENCRYPTION_KEY_ID, correlationId)).willReturn(response);
 
@@ -174,9 +174,9 @@ public class HealthCheckIntegrationTests {
                 HealthCheckResponse.Health.OK,
                 HealthCheckResponse.Health.OK,
                 HealthCheckResponse.Health.BAD)
-                .withDksCorrelationId(correlationId);
+                .withcorrelationId(correlationId);
 
-        mockMvc.perform(get(HEALTHCHECK_ENDPOINT + "?dksCorrelationId={correlationId}", correlationId))
+        mockMvc.perform(get(HEALTHCHECK_ENDPOINT + "?correlationId={correlationId}", correlationId))
                 .andExpect(content().json(new ObjectMapper().writeValueAsString(healthCheckResponse)))
                 .andExpect(status().isInternalServerError());
     }

--- a/src/test/java/uk/gov/dwp/dataworks/integration/HealthCheckIntegrationTests.java
+++ b/src/test/java/uk/gov/dwp/dataworks/integration/HealthCheckIntegrationTests.java
@@ -21,6 +21,8 @@ import uk.gov.dwp.dataworks.provider.DataKeyGeneratorProvider;
 
 import java.util.Objects;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -103,7 +105,7 @@ public class HealthCheckIntegrationTests {
         given(currentKeyIdProvider.canSeeDependencies()).willReturn(true);
         given(dataKeyGeneratorProvider.canSeeDependencies()).willReturn(true);
         given(dataKeyDecryptionProvider.canSeeDependencies()).willReturn(true);
-        given(currentKeyIdProvider.getKeyId()).willThrow(RuntimeException.class);
+        given(currentKeyIdProvider.getKeyId(anyString())).willThrow(RuntimeException.class);
 
         HealthCheckResponse healthCheckResponse = new HealthCheckResponse(HealthCheckResponse.Health.OK,
                 HealthCheckResponse.Health.BAD,
@@ -120,7 +122,7 @@ public class HealthCheckIntegrationTests {
         given(currentKeyIdProvider.canSeeDependencies()).willReturn(true);
         given(dataKeyGeneratorProvider.canSeeDependencies()).willReturn(true);
         given(dataKeyDecryptionProvider.canSeeDependencies()).willReturn(true);
-        given(currentKeyIdProvider.getKeyId()).willReturn("");
+        given(currentKeyIdProvider.getKeyId(anyString())).willReturn("");
         HealthCheckResponse healthCheckResponse = new HealthCheckResponse(HealthCheckResponse.Health.OK,
                 HealthCheckResponse.Health.BAD,
                 HealthCheckResponse.Health.BAD,
@@ -136,8 +138,8 @@ public class HealthCheckIntegrationTests {
         given(currentKeyIdProvider.canSeeDependencies()).willReturn(true);
         given(dataKeyGeneratorProvider.canSeeDependencies()).willReturn(true);
         given(dataKeyDecryptionProvider.canSeeDependencies()).willReturn(true);
-        given(currentKeyIdProvider.getKeyId()).willReturn(ENCRYPTION_KEY_ID);
-        given(dataKeyGeneratorProvider.generateDataKey(ENCRYPTION_KEY_ID)).willThrow(RuntimeException.class);
+        given(currentKeyIdProvider.getKeyId(anyString())).willReturn(ENCRYPTION_KEY_ID);
+        given(dataKeyGeneratorProvider.generateDataKey(eq(ENCRYPTION_KEY_ID), anyString())).willThrow(RuntimeException.class);
 
         HealthCheckResponse healthCheckResponse = new HealthCheckResponse(HealthCheckResponse.Health.OK,
                 HealthCheckResponse.Health.OK,
@@ -155,13 +157,13 @@ public class HealthCheckIntegrationTests {
         given(currentKeyIdProvider.canSeeDependencies()).willReturn(true);
         given(dataKeyGeneratorProvider.canSeeDependencies()).willReturn(true);
         given(dataKeyDecryptionProvider.canSeeDependencies()).willReturn(true);
-        given(currentKeyIdProvider.getKeyId()).willReturn(ENCRYPTION_KEY_ID);
+        given(currentKeyIdProvider.getKeyId(anyString())).willReturn(ENCRYPTION_KEY_ID);
         GenerateDataKeyResponse response =
                 new GenerateDataKeyResponse(ENCRYPTION_KEY_ID, PLAIN_TEXT_KEY, CIPHER_TEXT_DATA_KEY);
 
-        given(dataKeyGeneratorProvider.generateDataKey(ENCRYPTION_KEY_ID)).willReturn(response);
+        given(dataKeyGeneratorProvider.generateDataKey(ENCRYPTION_KEY_ID, "correlationid")).willReturn(response);
 
-        given(dataKeyDecryptionProvider.decryptDataKey(ENCRYPTION_KEY_ID, CIPHER_TEXT_DATA_KEY))
+        given(dataKeyDecryptionProvider.decryptDataKey(eq(ENCRYPTION_KEY_ID), eq(CIPHER_TEXT_DATA_KEY), anyString()))
                 .willThrow(RuntimeException.class);
 
         HealthCheckResponse healthCheckResponse = new HealthCheckResponse(HealthCheckResponse.Health.OK,
@@ -180,15 +182,15 @@ public class HealthCheckIntegrationTests {
         given(currentKeyIdProvider.canSeeDependencies()).willReturn(true);
         given(dataKeyGeneratorProvider.canSeeDependencies()).willReturn(true);
         given(dataKeyDecryptionProvider.canSeeDependencies()).willReturn(true);
-        given(currentKeyIdProvider.getKeyId()).willReturn(ENCRYPTION_KEY_ID);
+        given(currentKeyIdProvider.getKeyId(anyString())).willReturn(ENCRYPTION_KEY_ID);
         GenerateDataKeyResponse response =
                 new GenerateDataKeyResponse(ENCRYPTION_KEY_ID, PLAIN_TEXT_KEY, CIPHER_TEXT_DATA_KEY);
 
-        given(dataKeyGeneratorProvider.generateDataKey(ENCRYPTION_KEY_ID)).willReturn(response);
+        given(dataKeyGeneratorProvider.generateDataKey(eq(ENCRYPTION_KEY_ID), anyString())).willReturn(response);
 
         DecryptDataKeyResponse decryptResponse = new DecryptDataKeyResponse(ENCRYPTION_KEY_ID, PLAIN_TEXT_KEY);
 
-        given(dataKeyDecryptionProvider.decryptDataKey(ENCRYPTION_KEY_ID, CIPHER_TEXT_DATA_KEY + "_CHANGE"))
+        given(dataKeyDecryptionProvider.decryptDataKey(eq(ENCRYPTION_KEY_ID), eq(CIPHER_TEXT_DATA_KEY + "_CHANGE"), anyString()))
                 .willReturn(decryptResponse);
 
         HealthCheckResponse healthCheckResponse = new HealthCheckResponse(HealthCheckResponse.Health.OK,
@@ -208,15 +210,15 @@ public class HealthCheckIntegrationTests {
         given(currentKeyIdProvider.canSeeDependencies()).willReturn(true);
         given(dataKeyGeneratorProvider.canSeeDependencies()).willReturn(true);
         given(dataKeyDecryptionProvider.canSeeDependencies()).willReturn(true);
-        given(currentKeyIdProvider.getKeyId()).willReturn(ENCRYPTION_KEY_ID);
+        given(currentKeyIdProvider.getKeyId(anyString())).willReturn(ENCRYPTION_KEY_ID);
 
         GenerateDataKeyResponse response =
                 new GenerateDataKeyResponse(ENCRYPTION_KEY_ID, PLAIN_TEXT_KEY, CIPHER_TEXT_DATA_KEY);
 
-        given(dataKeyGeneratorProvider.generateDataKey(ENCRYPTION_KEY_ID)).willReturn(response);
+        given(dataKeyGeneratorProvider.generateDataKey(eq(ENCRYPTION_KEY_ID), anyString())).willReturn(response);
         DecryptDataKeyResponse decryptResponse = new DecryptDataKeyResponse(ENCRYPTION_KEY_ID, PLAIN_TEXT_KEY);
 
-        given(dataKeyDecryptionProvider.decryptDataKey(ENCRYPTION_KEY_ID, CIPHER_TEXT_DATA_KEY))
+        given(dataKeyDecryptionProvider.decryptDataKey(eq(ENCRYPTION_KEY_ID), eq(CIPHER_TEXT_DATA_KEY), anyString()))
                 .willReturn(decryptResponse);
 
         HealthCheckResponse healthCheckResponse = new HealthCheckResponse(HealthCheckResponse.Health.OK,

--- a/src/test/java/uk/gov/dwp/dataworks/provider/aws/AWSCurrentKeyIdProviderTest.java
+++ b/src/test/java/uk/gov/dwp/dataworks/provider/aws/AWSCurrentKeyIdProviderTest.java
@@ -25,6 +25,8 @@ import static org.mockito.Mockito.verify;
 @ActiveProfiles({"KMS", "UnitTest"})
 public class AWSCurrentKeyIdProviderTest {
 
+    private final String correlationId = "correlation";
+
     @Before
     public void init() {
         Mockito.reset(awsSimpleSystemsManagement);
@@ -36,7 +38,7 @@ public class AWSCurrentKeyIdProviderTest {
         GetParameterRequest request = getGetParameterRequest();
         GetParameterResult result = getGetParameterResult(expectedKeyId);
         given(awsSimpleSystemsManagement.getParameter(request)).willReturn(result);
-        Assert.assertEquals(expectedKeyId, currentKeyIdProvider.getKeyId());
+        Assert.assertEquals(expectedKeyId, currentKeyIdProvider.getKeyId(correlationId));
     }
 
     @Test(expected = CurrentKeyIdException.class)
@@ -63,7 +65,7 @@ public class AWSCurrentKeyIdProviderTest {
     @Test
     public void Should_Consider_Default_Value_When_MasterKey_Property_Not_Set() {
         given(awsSimpleSystemsManagement.getParameter(any())).willReturn(new GetParameterResult().withParameter(new Parameter()));
-        currentKeyIdProvider.getKeyId();
+        currentKeyIdProvider.getKeyId(correlationId);
         ArgumentCaptor<GetParameterRequest> captor = ArgumentCaptor.forClass(GetParameterRequest.class);
         verify(awsSimpleSystemsManagement).getParameter(captor.capture());
         GetParameterRequest getParameterRequest = captor.getValue();
@@ -73,7 +75,7 @@ public class AWSCurrentKeyIdProviderTest {
     private void throwException(Class<? extends Exception> e) throws CurrentKeyIdException {
         given(awsSimpleSystemsManagement.getParameter(ArgumentMatchers.any(GetParameterRequest.class))).willThrow(e);
         System.err.println("currentKeyIdProvider: '" + currentKeyIdProvider + "'");
-        currentKeyIdProvider.getKeyId();
+        currentKeyIdProvider.getKeyId(correlationId);
     }
 
     private GetParameterResult getGetParameterResult(String expectedKeyId) {

--- a/src/test/java/uk/gov/dwp/dataworks/provider/hsm/HsmDataKeyDecryptionProviderTest.java
+++ b/src/test/java/uk/gov/dwp/dataworks/provider/hsm/HsmDataKeyDecryptionProviderTest.java
@@ -75,7 +75,7 @@ public class HsmDataKeyDecryptionProviderTest {
             dataKeyDecryptionProvider.decryptDataKey(dataKeyEncryptionKeyId, encryptedDataKey, correlationId);
             fail("Expected a DataKeyDecryptionException");
         } catch (DataKeyDecryptionException ex) {
-            assertEquals("Failed to decrypt this data key due to an internal error. Try again later.", ex.getMessage());
+            assertEquals("Failed to decrypt this data key due to an internal error. Try again later. correlation_id: correlation", ex.getMessage());
         }
     }
 
@@ -89,7 +89,7 @@ public class HsmDataKeyDecryptionProviderTest {
             dataKeyDecryptionProvider.decryptDataKey(dataKeyEncryptionKeyId, "ENCRYPTED", correlationId);
             fail("Expected a CurrentKeyIdException");
         } catch (CurrentKeyIdException ex) {
-            assertEquals("Failed to retrieve the current key id.", ex.getMessage());
+            assertEquals("Failed to retrieve the current key id. correlation_id: correlation", ex.getMessage());
         }
     }
 

--- a/src/test/java/uk/gov/dwp/dataworks/provider/hsm/HsmDataKeyDecryptionProviderTest.java
+++ b/src/test/java/uk/gov/dwp/dataworks/provider/hsm/HsmDataKeyDecryptionProviderTest.java
@@ -49,12 +49,13 @@ public class HsmDataKeyDecryptionProviderTest {
         doNothing().when(hsmLoginManager).login();
         doNothing().when(hsmLoginManager).logout();
         String dataKeyEncryptionKeyId = "cloudhsm:" + privateKeyHandle + "/" + publicKeyHandle;
-        given(cryptoImplementationSupplier.decryptedKey(privateKeyHandle, encryptedDataKey)).willReturn(plaintextDataKey);
+        given(cryptoImplementationSupplier.decryptedKey(privateKeyHandle, encryptedDataKey, correlationId)).willReturn(plaintextDataKey);
 
         DecryptDataKeyResponse actual = dataKeyDecryptionProvider.decryptDataKey(dataKeyEncryptionKeyId, encryptedDataKey, correlationId);
 
         ArgumentCaptor<Integer> argumentCaptor = ArgumentCaptor.forClass(Integer.class);
-        verify(cryptoImplementationSupplier, times(1)).decryptedKey(argumentCaptor.capture(), same(encryptedDataKey));
+        verify(cryptoImplementationSupplier, times(1))
+                .decryptedKey(argumentCaptor.capture(), same(encryptedDataKey), eq(correlationId));
         DecryptDataKeyResponse expected = new DecryptDataKeyResponse(dataKeyEncryptionKeyId, plaintextDataKey);
         assertEquals(actual, expected);
     }
@@ -67,7 +68,8 @@ public class HsmDataKeyDecryptionProviderTest {
         doNothing().when(hsmLoginManager).login();
         doNothing().when(hsmLoginManager).logout();
         String dataKeyEncryptionKeyId = "cloudhsm:" + privateKeyHandle + "/" + publicKeyHandle;
-        given(cryptoImplementationSupplier.decryptedKey(privateKeyHandle, encryptedDataKey)).willThrow(CryptoImplementationSupplierException.class);
+        given(cryptoImplementationSupplier.decryptedKey(privateKeyHandle, encryptedDataKey, correlationId))
+                .willThrow(CryptoImplementationSupplierException.class);
 
         try {
             dataKeyDecryptionProvider.decryptDataKey(dataKeyEncryptionKeyId, encryptedDataKey, correlationId);

--- a/src/test/java/uk/gov/dwp/dataworks/provider/hsm/HsmDataKeyDecryptionProviderTest.java
+++ b/src/test/java/uk/gov/dwp/dataworks/provider/hsm/HsmDataKeyDecryptionProviderTest.java
@@ -32,6 +32,8 @@ import static org.mockito.Mockito.*;
 })
 public class HsmDataKeyDecryptionProviderTest {
 
+    private final String correlationId = "correlation";
+
     @Before
     public void init() {
         Mockito.reset(cryptoImplementationSupplier);
@@ -49,7 +51,7 @@ public class HsmDataKeyDecryptionProviderTest {
         String dataKeyEncryptionKeyId = "cloudhsm:" + privateKeyHandle + "/" + publicKeyHandle;
         given(cryptoImplementationSupplier.decryptedKey(privateKeyHandle, encryptedDataKey)).willReturn(plaintextDataKey);
 
-        DecryptDataKeyResponse actual = dataKeyDecryptionProvider.decryptDataKey(dataKeyEncryptionKeyId, encryptedDataKey);
+        DecryptDataKeyResponse actual = dataKeyDecryptionProvider.decryptDataKey(dataKeyEncryptionKeyId, encryptedDataKey, correlationId);
 
         ArgumentCaptor<Integer> argumentCaptor = ArgumentCaptor.forClass(Integer.class);
         verify(cryptoImplementationSupplier, times(1)).decryptedKey(argumentCaptor.capture(), same(encryptedDataKey));
@@ -68,7 +70,7 @@ public class HsmDataKeyDecryptionProviderTest {
         given(cryptoImplementationSupplier.decryptedKey(privateKeyHandle, encryptedDataKey)).willThrow(CryptoImplementationSupplierException.class);
 
         try {
-            dataKeyDecryptionProvider.decryptDataKey(dataKeyEncryptionKeyId, encryptedDataKey);
+            dataKeyDecryptionProvider.decryptDataKey(dataKeyEncryptionKeyId, encryptedDataKey, correlationId);
             fail("Expected a DataKeyDecryptionException");
         } catch (DataKeyDecryptionException ex) {
             assertEquals("Failed to decrypt this data key due to an internal error. Try again later.", ex.getMessage());
@@ -82,7 +84,7 @@ public class HsmDataKeyDecryptionProviderTest {
         doNothing().when(hsmLoginManager).logout();
 
         try {
-            dataKeyDecryptionProvider.decryptDataKey(dataKeyEncryptionKeyId, "ENCRYPTED");
+            dataKeyDecryptionProvider.decryptDataKey(dataKeyEncryptionKeyId, "ENCRYPTED", correlationId);
             fail("Expected a CurrentKeyIdException");
         } catch (CurrentKeyIdException ex) {
             assertEquals("Failed to retrieve the current key id.", ex.getMessage());

--- a/src/test/java/uk/gov/dwp/dataworks/provider/hsm/HsmDataKeyGeneratorProviderTest.java
+++ b/src/test/java/uk/gov/dwp/dataworks/provider/hsm/HsmDataKeyGeneratorProviderTest.java
@@ -106,7 +106,7 @@ public class HsmDataKeyGeneratorProviderTest {
             dataKeyGeneratorProvider.generateDataKey(dataKeyEncryptionKeyId, correlationId);
             fail("Expected a DataKeyGenerationException");
         } catch (DataKeyGenerationException ex){
-            assertEquals("Failed to generate a new data key due to an internal error. Try again later.", ex.getMessage());
+            assertEquals("Failed to generate a new data key due to an internal error. Try again later. correlation_id: correlation", ex.getMessage());
         }
     }
 
@@ -127,7 +127,7 @@ public class HsmDataKeyGeneratorProviderTest {
             dataKeyGeneratorProvider.generateDataKey(dataKeyEncryptionKeyId, correlationId);
             fail("Expected a DataKeyGenerationException");
         } catch (DataKeyGenerationException ex){
-            assertEquals("Failed to generate a new data key due to an internal error. Try again later.", ex.getMessage());
+            assertEquals("Failed to generate a new data key due to an internal error. Try again later. correlation_id: correlation", ex.getMessage());
         }
     }
 
@@ -138,7 +138,7 @@ public class HsmDataKeyGeneratorProviderTest {
             dataKeyGeneratorProvider.generateDataKey(dataKeyEncryptionKeyId, correlationId);
             fail("Expected a DataKeyGenerationException");
         } catch (CurrentKeyIdException ex){
-            assertEquals("Failed to retrieve the current key id.", ex.getMessage());
+            assertEquals("Failed to retrieve the current key id. correlation_id: correlation", ex.getMessage());
         }
     }
 

--- a/src/test/java/uk/gov/dwp/dataworks/provider/hsm/HsmDataKeyGeneratorProviderTest.java
+++ b/src/test/java/uk/gov/dwp/dataworks/provider/hsm/HsmDataKeyGeneratorProviderTest.java
@@ -56,14 +56,14 @@ public class HsmDataKeyGeneratorProviderTest {
         doNothing().when(hsmLoginManager).logout();
         CaviumKey key = Mockito.mock(CaviumKey.class);
         given(key.getEncoded()).willReturn(plainTextKey.getBytes());
-        given(cryptoImplementationSupplier.dataKey()).willReturn(key);
+        given(cryptoImplementationSupplier.dataKey(correlationId)).willReturn(key);
         ArgumentCaptor<Integer> argumentCaptor = ArgumentCaptor.forClass(Integer.class);
-        given(cryptoImplementationSupplier.encryptedKey(publicKeyHandle, key)).willReturn(encryptedDataKey.getBytes());
+        given(cryptoImplementationSupplier.encryptedKey(publicKeyHandle, key, correlationId)).willReturn(encryptedDataKey.getBytes());
 
         GenerateDataKeyResponse actual = dataKeyGeneratorProvider.generateDataKey(dataKeyEncryptionKeyId, correlationId);
 
-        verify(cryptoImplementationSupplier, times(1)).encryptedKey(argumentCaptor.capture(), same(key));
-        assertEquals(argumentCaptor.getValue(), new Integer(publicKeyHandle));
+        verify(cryptoImplementationSupplier, times(1)).encryptedKey(argumentCaptor.capture(), same(key), eq(correlationId));
+        assertEquals(argumentCaptor.getValue(), Integer.valueOf(publicKeyHandle));
         GenerateDataKeyResponse expected = new GenerateDataKeyResponse(dataKeyEncryptionKeyId, Base64
                 .getEncoder().encodeToString(plainTextKey.getBytes()), encryptedDataKey);
         assertEquals(actual, expected);
@@ -76,17 +76,17 @@ public class HsmDataKeyGeneratorProviderTest {
             CaviumKey mockKey = Mockito.mock(CaviumKey.class);
             given(mockKey.getEncoded()).willReturn("some bytes".getBytes());
             given(cryptoImplementationSupplier
-                    .dataKey())
+                    .dataKey(eq(correlationId)))
                     .willReturn(mockKey);
             given(cryptoImplementationSupplier
-                    .encryptedKey(ArgumentMatchers.any(), ArgumentMatchers.any()))
+                    .encryptedKey(any(), any(), eq(correlationId)))
                     .willThrow(new MasterKeystoreException("Boom"));
 
             dataKeyGeneratorProvider.generateDataKey("cloudhsm:1,2", correlationId);
             fail("Expected a MasterKeystoreException");
         } catch (MasterKeystoreException ex) {
             assertEquals("Boom", ex.getMessage());
-            verify(cryptoImplementationSupplier, times(MAX_ATTEMPTS)).encryptedKey(ArgumentMatchers.any(), ArgumentMatchers.any());
+            verify(cryptoImplementationSupplier, times(MAX_ATTEMPTS)).encryptedKey(any(), any(), eq(correlationId));
         }
     }
 
@@ -100,7 +100,7 @@ public class HsmDataKeyGeneratorProviderTest {
         String plainTextKey = "PLAINTEXTKEY";
         CaviumKey key = Mockito.mock(CaviumKey.class);
         given(key.getEncoded()).willReturn(plainTextKey.getBytes());
-        given(cryptoImplementationSupplier.dataKey()).willThrow(CryptoImplementationSupplierException.class);
+        given(cryptoImplementationSupplier.dataKey(correlationId)).willThrow(CryptoImplementationSupplierException.class);
 
         try {
             dataKeyGeneratorProvider.generateDataKey(dataKeyEncryptionKeyId, correlationId);
@@ -120,8 +120,8 @@ public class HsmDataKeyGeneratorProviderTest {
         String plainTextKey = "PLAINTEXTKEY";
         CaviumKey key = Mockito.mock(CaviumKey.class);
         given(key.getEncoded()).willReturn(plainTextKey.getBytes());
-        given(cryptoImplementationSupplier.dataKey()).willReturn(key);
-        given(cryptoImplementationSupplier.encryptedKey(publicKeyHandle, key)).willThrow(CryptoImplementationSupplierException.class);
+        given(cryptoImplementationSupplier.dataKey(correlationId)).willReturn(key);
+        given(cryptoImplementationSupplier.encryptedKey(publicKeyHandle, key, correlationId)).willThrow(CryptoImplementationSupplierException.class);
 
         try {
             dataKeyGeneratorProvider.generateDataKey(dataKeyEncryptionKeyId, correlationId);

--- a/src/test/java/uk/gov/dwp/dataworks/provider/kms/KMSDataKeyDecryptionProviderTest.java
+++ b/src/test/java/uk/gov/dwp/dataworks/provider/kms/KMSDataKeyDecryptionProviderTest.java
@@ -29,6 +29,8 @@ import static org.mockito.BDDMockito.given;
 @ActiveProfiles({"UnitTest", "KMS"})
 public class KMSDataKeyDecryptionProviderTest {
 
+    private final String correlationId = "correlation";
+
     @Before
     public void init() {
         Mockito.reset(awsKms);
@@ -48,7 +50,7 @@ public class KMSDataKeyDecryptionProviderTest {
         result.setPlaintext(ByteBuffer.wrap(plainTextDataKey.getBytes()));
         given(awsKms.decrypt(ArgumentMatchers.any(DecryptRequest.class))).willReturn(result);
         DecryptDataKeyResponse actual =
-                kmsDataKeyDecryptionProvider.decryptDataKey(dataKeyEncryptionKeyId, encryptedDataKey);
+                kmsDataKeyDecryptionProvider.decryptDataKey(dataKeyEncryptionKeyId, encryptedDataKey, correlationId);
         assertEquals(expected, actual);
     }
 
@@ -57,7 +59,7 @@ public class KMSDataKeyDecryptionProviderTest {
         byte[] largeAmountOfCypherText = new byte[DataKeyDecryptionProvider.MAX_PAYLOAD_SIZE + 1];
         Arrays.fill(largeAmountOfCypherText, (byte) 48);
         String decryptionArg = new String(largeAmountOfCypherText);
-        kmsDataKeyDecryptionProvider.decryptDataKey("DATAKEYENCRYPTIONKEYID", decryptionArg);
+        kmsDataKeyDecryptionProvider.decryptDataKey("DATAKEYENCRYPTIONKEYID", decryptionArg, correlationId);
     }
 
     @Test
@@ -76,7 +78,7 @@ public class KMSDataKeyDecryptionProviderTest {
         result.setPlaintext(ByteBuffer.wrap(plainTextDataKey.getBytes()));
         given(awsKms.decrypt(ArgumentMatchers.any(DecryptRequest.class))).willReturn(result);
         DecryptDataKeyResponse actual =
-                kmsDataKeyDecryptionProvider.decryptDataKey(dataKeyEncryptionKeyId, decryptionArg);
+                kmsDataKeyDecryptionProvider.decryptDataKey(dataKeyEncryptionKeyId, decryptionArg, correlationId);
         assertEquals(expected, actual);
     }
 
@@ -134,7 +136,7 @@ public class KMSDataKeyDecryptionProviderTest {
         String encryptedDataKey = "ENCRYPTEDDATAKEY";
         String dataKeyEncryptionKeyId = "DATAKEYENCRYPTIONKEYID";
         given(awsKms.decrypt(ArgumentMatchers.any(DecryptRequest.class))).willThrow(exceptionClass);
-        kmsDataKeyDecryptionProvider.decryptDataKey(dataKeyEncryptionKeyId, encryptedDataKey);
+        kmsDataKeyDecryptionProvider.decryptDataKey(dataKeyEncryptionKeyId, encryptedDataKey, correlationId);
     }
 
     @Autowired

--- a/src/test/java/uk/gov/dwp/dataworks/provider/kms/KMSDataKeyGeneratorProviderTest.java
+++ b/src/test/java/uk/gov/dwp/dataworks/provider/kms/KMSDataKeyGeneratorProviderTest.java
@@ -26,6 +26,8 @@ import static org.mockito.BDDMockito.given;
 @ActiveProfiles({ "UnitTest", "KMS" })
 public class KMSDataKeyGeneratorProviderTest {
 
+    private final String correlationId = "correlation";
+
     @Test
     public void generateDataKey() throws MasterKeystoreException {
         String dataKeyEncryptionKeyId = "DATAKEYENCRYPTIONKEYID";
@@ -44,7 +46,7 @@ public class KMSDataKeyGeneratorProviderTest {
         GenerateDataKeyResponse expected = new GenerateDataKeyResponse(dataKeyEncryptionKeyId,
                 encoder.encodeToString(plainTextKey.getBytes()), encoder.encodeToString(encryptedDataKey.getBytes()));
 
-        GenerateDataKeyResponse actual = dataKeyGeneratorProvider.generateDataKey(dataKeyEncryptionKeyId);
+        GenerateDataKeyResponse actual = dataKeyGeneratorProvider.generateDataKey(dataKeyEncryptionKeyId, correlationId);
 
         assertEquals(expected, actual);
     }
@@ -86,7 +88,7 @@ public class KMSDataKeyGeneratorProviderTest {
 
     private void throwException(Class<? extends Exception> e) throws CurrentKeyIdException, MasterKeystoreException {
         given(awsKms.generateDataKey(ArgumentMatchers.any(GenerateDataKeyRequest.class))).willThrow(e);
-        dataKeyGeneratorProvider.generateDataKey("DATAKEYENCRYPTIONKEYID");
+        dataKeyGeneratorProvider.generateDataKey("DATAKEYENCRYPTIONKEYID", correlationId);
     }
 
     @Autowired

--- a/src/test/java/uk/gov/dwp/dataworks/provider/standalone/StandaloneCurrentKeyIdProviderTest.java
+++ b/src/test/java/uk/gov/dwp/dataworks/provider/standalone/StandaloneCurrentKeyIdProviderTest.java
@@ -5,10 +5,9 @@ import org.junit.Test;
 
 public class StandaloneCurrentKeyIdProviderTest {
     private final StandaloneCurrentKeyIdProvider providerToTest = new StandaloneCurrentKeyIdProvider();
-
     @Test
     public void getKeyId() {
-        Assert.assertEquals("Must be STANDALONE", "STANDALONE", providerToTest.getKeyId());
+        Assert.assertEquals("Must be STANDALONE", "STANDALONE", providerToTest.getKeyId("correlation"));
     }
 
     @Test

--- a/src/test/java/uk/gov/dwp/dataworks/provider/standalone/StandaloneDataKeyDecryptionProviderTest.java
+++ b/src/test/java/uk/gov/dwp/dataworks/provider/standalone/StandaloneDataKeyDecryptionProviderTest.java
@@ -11,14 +11,16 @@ public class StandaloneDataKeyDecryptionProviderTest {
     private final StandaloneDataKeyDecryptionProvider decryptionProvider = new StandaloneDataKeyDecryptionProvider();
 
     @Test
-    public void canDecryptKeys(){
+    public void canDecryptKeys() {
         // Create key
-        GenerateDataKeyResponse keys = generatorProvider.generateDataKey(currentKeyIdProvider.getKeyId());
+        String correlationId = "correlation";
+        GenerateDataKeyResponse keys = generatorProvider.generateDataKey(currentKeyIdProvider.getKeyId(correlationId), correlationId);
 
         // Decrypt key
         DecryptDataKeyResponse decrypted = decryptionProvider.decryptDataKey(
                 keys.dataKeyEncryptionKeyId,
-                keys.ciphertextDataKey);
+                keys.ciphertextDataKey,
+                correlationId);
 
         // What went in, must come out
         Assert.assertEquals(keys.plaintextDataKey, decrypted.plaintextDataKey);

--- a/src/test/java/uk/gov/dwp/dataworks/provider/standalone/StandaloneDataKeyGeneratorProviderTest.java
+++ b/src/test/java/uk/gov/dwp/dataworks/provider/standalone/StandaloneDataKeyGeneratorProviderTest.java
@@ -5,14 +5,17 @@ import org.junit.Test;
 import uk.gov.dwp.dataworks.dto.GenerateDataKeyResponse;
 
 public class StandaloneDataKeyGeneratorProviderTest {
+
     private final StandaloneCurrentKeyIdProvider currentKeyIdProvider = new StandaloneCurrentKeyIdProvider();
     private final StandaloneDataKeyGeneratorProvider generatorProvider = new StandaloneDataKeyGeneratorProvider();
 
+    private final String correlationId = "correlation";
+
     @Test
-    public void canGenerateKeys(){
+    public void canGenerateKeys() {
         // Create a key
-        GenerateDataKeyResponse keys = generatorProvider.generateDataKey(currentKeyIdProvider.getKeyId());
-        Assert.assertEquals(keys.dataKeyEncryptionKeyId, currentKeyIdProvider.getKeyId());
+        GenerateDataKeyResponse keys = generatorProvider.generateDataKey(currentKeyIdProvider.getKeyId(correlationId), correlationId);
+        Assert.assertEquals(keys.dataKeyEncryptionKeyId, currentKeyIdProvider.getKeyId(correlationId));
         Assert.assertNotNull(keys.ciphertextDataKey);
         Assert.assertNotNull(keys.plaintextDataKey);
     }

--- a/src/test/java/uk/gov/dwp/dataworks/services/DataKeyServiceTest.java
+++ b/src/test/java/uk/gov/dwp/dataworks/services/DataKeyServiceTest.java
@@ -26,13 +26,10 @@ import java.util.Objects;
 })
 public class DataKeyServiceTest {
 
-    @Autowired
-    private CacheManager cacheManager;
-
     @Before
     public void init() {
         Mockito.reset(currentKeyIdProvider);
-        //hsmCredentialsProvider.clearCache();
+
         for (String name : cacheManager.getCacheNames()) {
             Objects.requireNonNull(cacheManager.getCache(name)).clear();
         }
@@ -43,7 +40,7 @@ public class DataKeyServiceTest {
         dataKeyService.currentKeyId();
         dataKeyService.currentKeyId();
         dataKeyService.currentKeyId();
-        // Verification
+
         Mockito.verify(currentKeyIdProvider, Mockito.times(1)).getKeyId();
     }
 
@@ -52,9 +49,12 @@ public class DataKeyServiceTest {
         dataKeyService.currentKeyId();
         Thread.sleep(2000);
         dataKeyService.currentKeyId();
-        // Verification
+
         Mockito.verify(currentKeyIdProvider, Mockito.times(2)).getKeyId();
     }
+
+    @Autowired
+    private CacheManager cacheManager;
 
     @Autowired
     private DataKeyService dataKeyService;

--- a/src/test/java/uk/gov/dwp/dataworks/services/DataKeyServiceTest.java
+++ b/src/test/java/uk/gov/dwp/dataworks/services/DataKeyServiceTest.java
@@ -26,6 +26,8 @@ import java.util.Objects;
 })
 public class DataKeyServiceTest {
 
+    private final String correlationId = "correlation";
+
     @Before
     public void init() {
         Mockito.reset(currentKeyIdProvider);
@@ -37,20 +39,20 @@ public class DataKeyServiceTest {
 
     @Test
     public void Should_Verify_Cache_Returns_Key_Id_When_Invoked_With_In_Cache_Eviction_Interval() {
-        dataKeyService.currentKeyId();
-        dataKeyService.currentKeyId();
-        dataKeyService.currentKeyId();
+        dataKeyService.currentKeyId(correlationId);
+        dataKeyService.currentKeyId(correlationId);
+        dataKeyService.currentKeyId(correlationId);
 
-        Mockito.verify(currentKeyIdProvider, Mockito.times(1)).getKeyId();
+        Mockito.verify(currentKeyIdProvider, Mockito.times(1)).getKeyId(correlationId);
     }
 
     @Test
     public void Should_Verify_Cache_Evicts_At_Specified_Interval() throws InterruptedException {
-        dataKeyService.currentKeyId();
+        dataKeyService.currentKeyId(correlationId);
         Thread.sleep(2000);
-        dataKeyService.currentKeyId();
+        dataKeyService.currentKeyId(correlationId);
 
-        Mockito.verify(currentKeyIdProvider, Mockito.times(2)).getKeyId();
+        Mockito.verify(currentKeyIdProvider, Mockito.times(2)).getKeyId(correlationId);
     }
 
     @Autowired

--- a/src/test/java/uk/gov/dwp/dataworks/services/HealthCheckServiceTest.java
+++ b/src/test/java/uk/gov/dwp/dataworks/services/HealthCheckServiceTest.java
@@ -16,6 +16,8 @@ import uk.gov.dwp.dataworks.provider.DataKeyDecryptionProvider;
 import uk.gov.dwp.dataworks.provider.DataKeyGeneratorProvider;
 import uk.gov.dwp.dataworks.service.HealthCheckService;
 
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 import static uk.gov.dwp.dataworks.dto.HealthCheckResponse.Health.OK;
 
 @RunWith(SpringRunner.class)
@@ -42,15 +44,15 @@ public class HealthCheckServiceTest {
 
     @Test
     public void Should_Run_Healthcheck_Initially_After_One_Second() throws InterruptedException  {
-        Mockito.when(healthCheckController.healthCheck()).thenReturn(mockHealthOkResponse);
+        when(healthCheckController.healthCheck(anyString())).thenReturn(mockHealthOkResponse);
         Thread.sleep(1000);
-        Mockito.verify(healthCheckController, Mockito.times(1)).healthCheck();
+        verify(healthCheckController, times(1)).healthCheck(anyString());
     }
 
     @Test
     public void Should_Run_Healthcheck_At_Specified_Interval() throws InterruptedException {
-        Mockito.when(healthCheckController.healthCheck()).thenReturn(mockHealthOkResponse);
+        when(healthCheckController.healthCheck(anyString())).thenReturn(mockHealthOkResponse);
         Thread.sleep(3000);
-        Mockito.verify(healthCheckController, Mockito.times(3)).healthCheck();
+        verify(healthCheckController, times(3)).healthCheck(anyString());
     }
 }

--- a/src/test/java/uk/gov/dwp/dataworks/services/HealthCheckServiceTest.java
+++ b/src/test/java/uk/gov/dwp/dataworks/services/HealthCheckServiceTest.java
@@ -2,7 +2,6 @@ package uk.gov.dwp.dataworks.services;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -16,7 +15,6 @@ import uk.gov.dwp.dataworks.provider.DataKeyDecryptionProvider;
 import uk.gov.dwp.dataworks.provider.DataKeyGeneratorProvider;
 import uk.gov.dwp.dataworks.service.HealthCheckService;
 
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static uk.gov.dwp.dataworks.dto.HealthCheckResponse.Health.OK;
 
@@ -25,7 +23,8 @@ import static uk.gov.dwp.dataworks.dto.HealthCheckResponse.Health.OK;
 @TestPropertySource(properties = {"healthcheck.interval=1000", "scheduling.enabled=true"})
 public class HealthCheckServiceTest {
 
-    private final ResponseEntity<HealthCheckResponse> mockHealthOkResponse = org.springframework.http.ResponseEntity.ok(new HealthCheckResponse(OK, OK, OK, OK, OK));
+    private final ResponseEntity<HealthCheckResponse> mockHealthOkResponse = ResponseEntity.ok(
+            new HealthCheckResponse(OK, OK, OK, OK, OK));
 
     @Autowired
     private HealthCheckService healthCheckService;
@@ -45,14 +44,14 @@ public class HealthCheckServiceTest {
     @Test
     public void Should_Run_Healthcheck_Initially_After_One_Second() throws InterruptedException  {
         when(healthCheckController.healthCheck(anyString())).thenReturn(mockHealthOkResponse);
-        Thread.sleep(1000);
+        Thread.sleep(1001);
         verify(healthCheckController, times(1)).healthCheck(anyString());
     }
 
     @Test
     public void Should_Run_Healthcheck_At_Specified_Interval() throws InterruptedException {
         when(healthCheckController.healthCheck(anyString())).thenReturn(mockHealthOkResponse);
-        Thread.sleep(3000);
+        Thread.sleep(3001);
         verify(healthCheckController, times(3)).healthCheck(anyString());
     }
 }


### PR DESCRIPTION
DW-3354 add optional client correlation id to DKS. Log as correlation_id. Put in all the logs for production debugging of HSM errors.